### PR TITLE
KAS-1458 filter causes resource to miss changes

### DIFF
--- a/repository/helpers.js
+++ b/repository/helpers.js
@@ -699,11 +699,6 @@ const copySetOfTempToTarget = async function(queryEnv) {
         <${target}> ?p ?o .
         FILTER (?p NOT IN ( ext:yggdrasilLeft, ext:yggdrasilRight ) )
       }
-      FILTER ( NOT EXISTS {
-        GRAPH <${queryEnv.targetGraph}> {
-           <${target}> ?p ?o.
-        }
-     })
     }`;
     await queryEnv.run(query);
 


### PR DESCRIPTION
This filter was added to reduce the calls to DB (originally in feature/cleanup-and-performance)

In the case of overheid graph, we add the relations the the documents but not the documents themselves in the first release to the users.
In the second run, after setting a prop in meeting, we add the documents.
mu-cl-resources picks up changes to the db, but in this case, the relations have not changed since they were already pointing to the correct document URI and no cache clear is triggered