### PR TITLE
Feature/KAS-1425 model refactor: Activity

### DIFF
--- a/handle-deltas.js
+++ b/handle-deltas.js
@@ -31,6 +31,7 @@ const handleDeltaRelatedToAgenda = async function(subjects, queryEnv) {
 
 const pathsToAgenda = {
   'agendaitem': ['^dct:hasPart'],
+  'agenda-activity' : ['besluitvorming:genereertAgendapunt / ^dct:hasPart'],
   'subcase': ['^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt / ^dct:hasPart'],
   'meeting': ['^besluitvorming:isAgendaVoor'],
   'newsletter-info': [
@@ -84,6 +85,7 @@ const pathsToAgenda = {
 const typeUris = {
   'agenda': 'besluitvorming:Agenda',
   'agendaitem': 'besluit:Agendapunt',
+  'agenda-activity': 'besluitvorming:Agendering',
   'subcase': 'dbpedia:UnitOfWork',
   'meeting': 'besluit:Vergaderactiviteit',
   'newsletter-info': 'besluitvorming:NieuwsbriefInfo',

--- a/handle-deltas.js
+++ b/handle-deltas.js
@@ -31,7 +31,7 @@ const handleDeltaRelatedToAgenda = async function(subjects, queryEnv) {
 
 const pathsToAgenda = {
   'agendaitem': ['^dct:hasPart'],
-  'subcase': ['besluitvorming:isGeagendeerdVia / ^dct:hasPart'],
+  'subcase': ['^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt / ^dct:hasPart'],
   'meeting': ['^besluitvorming:isAgendaVoor'],
   'newsletter-info': [
     { path: '^prov:generated', nextRDFType: 'subcase' },
@@ -39,10 +39,6 @@ const pathsToAgenda = {
   ],
   'consultation-request': [
     { path: '^ext:bevatConsultatievraag', nextRDFType: 'subcase' }
-  ],
-  'subcase-phase': [
-    { path: '^ext:subcaseProcedurestapFase', nextRDFType: 'subcase' },
-    { path: '^ext:subcaseAgendapuntFase', nextRDFType: 'agendaitem' }
   ],
   'decision': [
     { path: '^ext:procedurestapHeeftBesluit', nextRDFType: 'subcase' },
@@ -92,7 +88,6 @@ const typeUris = {
   'meeting': 'besluit:Vergaderactiviteit',
   'newsletter-info': 'besluitvorming:NieuwsbriefInfo',
   'consultation-request': 'besluitvorming:Consultatievraag',
-  'subcase-phase': 'ext:ProcedurestapFase',
   'decision': 'besluit:Besluit',
   'meeting-record': 'ext:Notule',
   'case': 'dossier:Dossier',

--- a/repository/helpers.js
+++ b/repository/helpers.js
@@ -340,7 +340,7 @@ const addAllVisibleRelatedDocuments = async (queryEnv, extraFilters = "") => {
 };
 
 const addAllRelatedToAgenda = (queryEnv, extraFilters, relationProperties) => {
-  relationProperties = relationProperties || ['dct:hasPart', 'ext:mededeling', 'besluitvorming:isAgendaVoor', '^besluitvorming:behandelt', '( dct:hasPart / ^besluitvorming:isGeagendeerdVia )'];
+  relationProperties = relationProperties || ['dct:hasPart', 'ext:mededeling', 'besluitvorming:isAgendaVoor', '^besluitvorming:behandelt', '( dct:hasPart / ^besluitvorming:genereertAgendapunt / besluitvorming:vindtPlaatsTijdens )'];
   extraFilters = extraFilters || '';
 
   const query = `
@@ -365,7 +365,7 @@ const addAllRelatedToAgenda = (queryEnv, extraFilters, relationProperties) => {
       ?s a ?thing .
 
       { { ?s a dossier:Dossier .
-          ?s ^besluitvorming:isGeagendeerdVia ?agendaitem .
+          ?s dossier:doorloopt / ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendaitem .
           ?agenda dct:hasPart ?agendaitem .
           ?agendaitem besluitvorming:formeelOK <http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636>.
         }
@@ -448,7 +448,7 @@ const addRelatedToAgendaItemBatched = async (queryEnv, extraFilters) => {
        }
      }}
      GRAPH <${queryEnv.adminGraph}> {
-       ?target (ext:subcaseAgendapuntFase | ext:bevatReedsBezorgdAgendapuntDocumentversie | ext:agendapuntGoedkeuring | ext:heeftVerdaagd | besluitvorming:opmerking | ^besluitvorming:isGeagendeerdVia) ?s .
+       ?target ( ext:bevatReedsBezorgdAgendapuntDocumentversie | ext:agendapuntGoedkeuring | besluitvorming:opmerking | ^besluitvorming:genereertAgendapunt / besluitvorming:vindtPlaatsTijdens) ?s .
        ?s a ?thing .
 
        FILTER NOT EXISTS {
@@ -511,7 +511,7 @@ const addRelatedToSubcaseBatched = async (queryEnv, extraFilters) => {
                  }}
 
      GRAPH <${queryEnv.adminGraph}> {
-       ?target ( ext:bevatReedsBezorgdeDocumentversie | ^dossier:doorloopt | ext:subcaseProcedurestapFase | ext:bevatConsultatievraag | ext:procedurestapGoedkeuring | besluitvorming:opmerking ) ?s .
+       ?target ( ext:bevatReedsBezorgdeDocumentversie | ^dossier:doorloopt | ext:bevatConsultatievraag | ext:procedurestapGoedkeuring | besluitvorming:opmerking ) ?s .
        ?s a ?thing .
 
        FILTER NOT EXISTS {
@@ -843,7 +843,7 @@ const addAllDecisions = (queryEnv, extraFilters) => {
       ?agenda dct:hasPart ?agendaitem.
       ?agenda besluitvorming:isAgendaVoor ?session.
       ?session ext:releasedDecisions ?date.
-      ?subcase besluitvorming:isGeagendeerdVia ?agendaitem.
+      ?subcase ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendaitem.
       ?subcase ext:procedurestapHeeftBesluit ?s.
       ${extraFilters}
     }

--- a/repository/helpers.js
+++ b/repository/helpers.js
@@ -340,7 +340,7 @@ const addAllVisibleRelatedDocuments = async (queryEnv, extraFilters = "") => {
 };
 
 const addAllRelatedToAgenda = (queryEnv, extraFilters, relationProperties) => {
-  relationProperties = relationProperties || ['dct:hasPart', 'ext:mededeling', 'besluitvorming:isAgendaVoor', '^besluitvorming:behandelt', '( dct:hasPart / ^besluitvorming:genereertAgendapunt / besluitvorming:vindtPlaatsTijdens )'];
+  relationProperties = relationProperties || ['dct:hasPart', 'ext:mededeling', 'besluitvorming:isAgendaVoor', '^besluitvorming:behandelt','(dct:hasPart / ^besluitvorming:genereertAgendapunt)', '( dct:hasPart / ^besluitvorming:genereertAgendapunt / besluitvorming:vindtPlaatsTijdens )'];
   extraFilters = extraFilters || '';
 
   const query = `
@@ -448,7 +448,7 @@ const addRelatedToAgendaItemBatched = async (queryEnv, extraFilters) => {
        }
      }}
      GRAPH <${queryEnv.adminGraph}> {
-       ?target ( ext:bevatReedsBezorgdAgendapuntDocumentversie | ext:agendapuntGoedkeuring | besluitvorming:opmerking | ^besluitvorming:genereertAgendapunt / besluitvorming:vindtPlaatsTijdens) ?s .
+       ?target ( ext:bevatReedsBezorgdAgendapuntDocumentversie | ext:agendapuntGoedkeuring | besluitvorming:opmerking | ^besluitvorming:genereertAgendapunt | ^besluitvorming:genereertAgendapunt / besluitvorming:vindtPlaatsTijdens) ?s .
        ?s a ?thing .
 
        FILTER NOT EXISTS {


### PR DESCRIPTION
# :mag:  KAS-1425: Model refactor: activity model gebruiken
De refactor verlegt de relatie tussen procedurstap en agendaitem naar een tussenobject: de agendering-activiteit
Bij de refactor hoort ook een deel opkuis van: postponed, procedurestapfases en fasecodes.

## ✏️  What has changed

### handle-deltas.js:
Nieuwe modellen en types toevoegen.
Relaties naar agenda goed zetten

### repository/helpers.js:
Relatie tussen subcase en agendaitem ligt nu via agendering-activiteit 

Side effect: bij het goedzetten van de relaties opgemerkt dat een van onze queries vermoedelijk stuk was:
```
?s a dossier:Dossier .
?s ^besluitvorming:isGeagendeerdVia ?agendaitem .
```
Dit kan nooit een agendaitem als resultaat geven, aangezien ?s een dossier moet zijn, maar er ligt geen rechstreekse relatie naar agendaitem.

Vermoedelijk gevolg:
Als een agendaitem "nog niet formeel ok is", zouden we deze niet mogen tonen voor andere profielen.
Hiervoor lijkt deze filter te dienen.
Echter wordt er nu niets gefilterd en tonen we ze toch

Een van de problemen die ik zelf verwacht is dat er agendapunten gaan verdwijnen voor andere profielen
Aangezien we momenteel nog kunnen editeren op een goedgekeurde agenda (wat een reset van formeel ok triggert)
zijn er agendaitems die momenteel "nog niet formeel ok" zijn die het niet zouden mogen zijn.

Agendaitems op een goedgekeurde agenda zouden nooit "nog niet formeel ok" mogen zijn.
