### PR TITLE
Feature/kas 1691 batch public graph copy

### DIFF
--- a/repository/fill-public.js
+++ b/repository/fill-public.js
@@ -53,7 +53,7 @@ const copyClassesBatched = async function(queryEnv, classes, extraFilter) {
     }
   }`;
   await queryEnv.run(query);
-  return updatePropertiesOnAgendaItemsBatched(classesToDo);
+  return copyClassesBatched(classesToDo);
 }
 
 const fillUp = async function(queryEnv, extraFilter){
@@ -66,7 +66,7 @@ const fillUp = async function(queryEnv, extraFilter){
 
   const end = moment().utc();
   logStage(start, `fill public ended at: ${end.format()}`, queryEnv.targetGraph);
-  return result;
+  return;
 };
 
 export {

--- a/repository/fill-public.js
+++ b/repository/fill-public.js
@@ -31,12 +31,13 @@ const copyClassesBatched = async function(queryEnv, classes, extraFilter) {
     return;
   }
 
-  let classesToDo = [];
-  const batchSize = 5;
-  if (classes.length > batchSize) {
-    classesToDo = classes.splice(0, batchSize);
+  let classesBatched = [];
+  const batchSize = 2;
+  if (classes.length > 0) {
+    classesBatched = classes.splice(0, batchSize);
   }
 
+  console.log(`processing public classes: ${JSON.stringify(classesBatched)}`);
   const query = `
   INSERT {
     GRAPH <${queryEnv.targetGraph}> {
@@ -45,7 +46,7 @@ const copyClassesBatched = async function(queryEnv, classes, extraFilter) {
   } WHERE {
     GRAPH <${queryEnv.adminGraph}> {
       VALUES ?class {
-        <${classes.join('> <')}>
+        <${classesBatched.join('> <')}>
       }
       ?s a ?class .
       ?s ?p ?o .
@@ -53,7 +54,7 @@ const copyClassesBatched = async function(queryEnv, classes, extraFilter) {
     }
   }`;
   await queryEnv.run(query);
-  return copyClassesBatched(classesToDo);
+  return copyClassesBatched(queryEnv, classes, extraFilter);
 }
 
 const fillUp = async function(queryEnv, extraFilter){


### PR DESCRIPTION
Batch the copy of the public classes when using the environment property `RELOAD_ALL_DATA_ON_INIT`.

Used recursion to process batches based on the `batchSize`.
I didn't create an environment property for this size because it seemed unnecessary.
Added a console log which produces something like:

![image](https://user-images.githubusercontent.com/22245223/90252549-fbfa1d00-de3f-11ea-8e22-48bd3f5c6703.png)
