### PR TITLE
Migration/kas 1422 models agendaitem subcase

### DIFF
--- a/handle-deltas.js
+++ b/handle-deltas.js
@@ -73,7 +73,7 @@ const pathsToAgenda = {
   'document': [
     { path: '^ext:bevatDocumentversie', nextRDFType: 'subcase' },
     { path: '^ext:zittingDocumentversie', nextRDFType: 'meeting' },
-    { path: '^ext:bevatAgendapuntDocumentversie', nextRDFType: 'agendaitem' },
+    { path: '^besluitvorming:geagendeerdStuk', nextRDFType: 'agendaitem' },
     { path: '^ext:documentenVoorPublicatie', nextRDFType: 'newsletter-info' },
     { path: '^ext:documentenVoorPublicatie', nextRDFType: 'newsletter-info' },
     { path: '^ext:mededelingBevatDocumentversie', nextRDFType: 'announcement' },

--- a/repository/helpers.js
+++ b/repository/helpers.js
@@ -318,7 +318,7 @@ const addAllRelatedDocuments = async (queryEnv, extraFilters) => {
   }`;
   const constraints = [
     `
-      ?target ( ext:bevatDocumentversie | ext:zittingDocumentversie | ext:bevatReedsBezorgdeDocumentversie | ext:bevatAgendapuntDocumentversie | ext:bevatReedsBezorgdAgendapuntDocumentversie | ext:mededelingBevatDocumentversie | ext:documentenVoorPublicatie | ext:documentenVoorBeslissing | ext:getekendeDocumentVersiesVoorNotulen | dct:hasPart | prov:generated ) ?s .
+      ?target ( ext:bevatDocumentversie | ext:zittingDocumentversie | ext:bevatReedsBezorgdeDocumentversie | besluitvorming:geagendeerdStuk | ext:bevatReedsBezorgdAgendapuntDocumentversie | ext:mededelingBevatDocumentversie | ext:documentenVoorPublicatie | ext:documentenVoorBeslissing | ext:getekendeDocumentVersiesVoorNotulen | dct:hasPart | prov:generated ) ?s .
       ?s a dossier:Stuk .
     `,
     `
@@ -367,10 +367,10 @@ const addAllRelatedToAgenda = (queryEnv, extraFilters, relationProperties) => {
       { { ?s a dossier:Dossier .
           ?s dossier:doorloopt / ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendaitem .
           ?agenda dct:hasPart ?agendaitem .
-          ?agendaitem besluitvorming:formeelOK <http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636>.
+          ?agendaitem ext:formeelOK <http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636>.
         }
         UNION
-        { ?s besluitvorming:formeelOK <http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636> . }
+        { ?s ext:formeelOK <http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636> . }
         UNION
         { FILTER NOT EXISTS {
             VALUES (?restrictedType) {


### PR DESCRIPTION
# KAS-1422: uiteentrekken van agendaitem / subcase modellen
In deze model refactor heb ik gekeken welke data we nog onnodige dupliceren op beide modellen en ook vergelijken hoe het in het nieuwe oslo model zit.
Hieruit is gebleken dat de duplicatie al fel verminderd is t.o.v. vroeger, toen het ticket aangemaakt geweest is.
Ik heb voornamelijk wat prefixen correct gezet, en verwijdert wat weg mocht.

## ✏️ What has changed
- ext:bevatAgendapuntDocumentversie => besluitvorming:geagendeerdStuk
- besluitvorming:formeelOK => ext:formeelOK