### PR TITLE
Feature/KAS-1139 formeel ok status check removed

### DIFF
--- a/repository/helpers.js
+++ b/repository/helpers.js
@@ -369,10 +369,7 @@ const addAllRelatedToAgenda = (queryEnv, extraFilters, relationProperties) => {
       { { ?s a dossier:Dossier .
           ?s dossier:doorloopt / ^besluitvorming:vindtPlaatsTijdens / besluitvorming:genereertAgendapunt ?agendaitem .
           ?agenda dct:hasPart ?agendaitem .
-          ?agendaitem ext:formeelOK <http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636>.
         }
-        UNION
-        { ?s ext:formeelOK <http://kanselarij.vo.data.gift/id/concept/goedkeurings-statussen/CC12A7DB-A73A-4589-9D53-F3C2F4A40636> . }
         UNION
         { FILTER NOT EXISTS {
             VALUES (?restrictedType) {

--- a/repository/helpers.js
+++ b/repository/helpers.js
@@ -371,6 +371,8 @@ const addAllRelatedToAgenda = (queryEnv, extraFilters, relationProperties) => {
           ?agenda dct:hasPart ?agendaitem .
         }
         UNION
+        { ?s a besluit:Agendapunt .}
+        UNION
         { FILTER NOT EXISTS {
             VALUES (?restrictedType) {
               (dossier:Dossier) (besluit:Agendapunt)


### PR DESCRIPTION
removed filtering on formal ok status on approved agendas (design agenda's are not propagated, so removing the filter suffices)

Check the ticket for local testing to prove working code (
https://kanselarij.atlassian.net/browse/KAS-1139