### PR TITLE
KAS-3143 remove check on mail campaign for newsitems

### DIFF
--- a/repository/collectors/decision-collection.js
+++ b/repository/collectors/decision-collection.js
@@ -1,5 +1,5 @@
 import { updateTriplestore } from '../triplestore';
-import { decisionsReleaseFilter, newsitemReleaseFilter } from './release-validations';
+import { decisionsReleaseFilter } from './release-validations';
 
 /**
  * Helpers to collect data about:
@@ -48,8 +48,8 @@ async function collectReleasedAgendaitemTreatments(distributor) {
  * Collect related newsitems for the relevant agendaitem-treatments
  * from the distributor's source graph in the temp graph.
  *
- * If 'validateNewsitemsRelease' is enabled on the distributor's release options
- * newsitems are only copied if they have already been published.
+ * If 'validateDecisionsRelease' is enabled on the distributor's release options
+ * newsitems are only copied if the decisions of the meeting have already been released.
  */
 async function collectReleasedNewsitems(distributor) {
   const properties = [
@@ -73,7 +73,7 @@ async function collectReleasedNewsitems(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
-          ${newsitemReleaseFilter(distributor.releaseOptions.validateNewsitemsRelease)}
+          ${decisionsReleaseFilter(distributor.releaseOptions.validateDecisionsRelease)}
           ?treatment ${path} ?s .
           ?s a ?type .
         }

--- a/repository/collectors/meeting-collection.js
+++ b/repository/collectors/meeting-collection.js
@@ -1,5 +1,5 @@
 import { updateTriplestore } from '../triplestore';
-import { newsitemReleaseFilter } from './release-validations';
+import { decisionsReleaseFilter } from './release-validations';
 
 /**
  * Helpers to collect data about:
@@ -43,8 +43,8 @@ async function collectMeetings(distributor) {
  * Collect related newsletters for the relevant meetings
  * from the distributor's source graph in the temp graph.
  *
- * If 'validateNewsitemsRelease' is enabled on the distributor's release options
- * newsletters are only copied if they have already been published.
+ * If 'validateDecisionsRelease' is enabled on the distributor's release options
+ * newsitems are only copied if the decisions of the meeting have already been released.
  */
 async function collectReleasedNewsletter(distributor) {
   const properties = [
@@ -68,7 +68,7 @@ async function collectReleasedNewsletter(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
-          ${newsitemReleaseFilter(distributor.releaseOptions.validateNewsitemsRelease)}
+          ${decisionsReleaseFilter(distributor.releaseOptions.validateDecisionsRelease)}
           ?meeting ${path} ?s .
           ?s a ?type .
         }

--- a/repository/collectors/release-validations.js
+++ b/repository/collectors/release-validations.js
@@ -14,14 +14,6 @@ export function decisionsReleaseFilter(isEnabled) {
   }
 }
 
-export function newsitemReleaseFilter(isEnabled) {
-  if (isEnabled) {
-    return '?agenda besluitvorming:isAgendaVoor / ext:releasedDecisions ?decisionReleaseDate .';
-  } else {
-    return '';
-  }
-}
-
 export function documentsReleaseFilter(isEnabled) {
   if (isEnabled) {
     return '?agenda besluitvorming:isAgendaVoor / ext:releasedDocuments ?documentsReleaseDate .';

--- a/repository/collectors/release-validations.js
+++ b/repository/collectors/release-validations.js
@@ -16,11 +16,7 @@ export function decisionsReleaseFilter(isEnabled) {
 
 export function newsitemReleaseFilter(isEnabled) {
   if (isEnabled) {
-    return `
-        ?agenda besluitvorming:isAgendaVoor ?meeting .
-        ?meeting ext:releasedDecisions ?decisionReleaseDate .
-        ?meeting ext:heeftMailCampagnes / ext:isVerstuurdOp ?sentMailDate .
-    `;
+    return '?agenda besluitvorming:isAgendaVoor / ext:releasedDecisions ?decisionReleaseDate .';
   } else {
     return '';
   }

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -13,8 +13,7 @@ class Distributor {
 
     this.releaseOptions = {
       validateDecisionsRelease: false,
-      validateDocumentsRelease: false,
-      validateNewsitemsRelease: false
+      validateDocumentsRelease: false
     };
   }
 

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -35,8 +35,7 @@ export default class GovernmentDistributor extends Distributor {
 
     this.releaseOptions = {
       validateDecisionsRelease: true,
-      validateDocumentsRelease: true,
-      validateNewsitemsRelease: true
+      validateDocumentsRelease: true
     };
   }
 


### PR DESCRIPTION
Door het wegvallen van de check of de mail-campagne al verzonden is, was er geen onderscheid meer tussen `validateNewsitemsRelease` en `validateDecisionsRelease`. Ik heb `validateNewsitemsRelease` daarom overal vervangen door `validateDecisionsRelease`.