### PR TITLE
Add mechanism to filter out triples from temp graph before propagating

### DIFF
--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -178,7 +178,16 @@ class Distributor {
    */
   async filterCollectedDetails() {
     let offset = 0;
-    const count = await countResources({ graph: this.tempGraph, type: 'http://data.vlaanderen.be/ns/besluit#Agendapunt' });
+    const summary = await queryTriplestore(`
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    SELECT (COUNT(?s) AS ?count) WHERE {
+      GRAPH <${this.tempGraph}> {
+        ?s a besluit:Agendapunt .
+        ?s ext:privateComment ?o .
+      }
+    }`);
+    const count = summary.results.bindings.map(b => b['count'].value);
 
     const deleteStatement =`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

--- a/repository/query-helpers.js
+++ b/repository/query-helpers.js
@@ -63,10 +63,10 @@ async function countResources({ graph, type = null, lineage = null }) {
 }
 
 async function deleteResource({ graph, type = null,  subject = null, predicate = null, object = null, objectType = null }) {
-  const subjectVar = subject ? `${sparqlEscapeUri(subject)}` : '?s';
-  const predicateVar = predicate ? `${sparqlEscapeUri(predicate)}` : '?p';
-  const objectVar = object ? `${sparqlEscape(object, objectType ?? 'uri')}` : '?o';
-  const typeStatement = type ? `${subjectVar} a <${type}> .` : '';
+  const subjectStatement = subject ? `BIND(${sparqlEscapeUri(subject)} AS ?s) .` : '';
+  const predicateStatement = predicate ? `BIND(${sparqlEscapeUri(predicate)} AS ?p) .` : '';
+  const objectStatement = object ? `BIND(${sparqlEscape(object, objectType ?? 'uri')} AS ?o) .` : '';
+  const typeStatement = type ? `?s a <${type}> .` : '';
 
   const count = await countTriples({ graph, subject, predicate, object, objectType });
   let offset = 0;
@@ -77,7 +77,7 @@ async function deleteResource({ graph, type = null,  subject = null, predicate =
   const deleteStatement = `
     DELETE {
       GRAPH <${graph}> {
-        ${subjectVar} ${predicateVar} ${objectVar} .
+        ?s ?p ?o .
       }
     }
     WHERE {
@@ -85,7 +85,10 @@ async function deleteResource({ graph, type = null,  subject = null, predicate =
         SELECT ?s ?p ?o
           WHERE {
             ${typeStatement}
-            ${subjectVar} ${predicateVar} ${objectVar} .
+            ${subjectStatement}
+            ${predicateStatement}
+            ${objectStatement}
+            ?s ?p ?o .
           }
           LIMIT ${MU_AUTH_PAGE_SIZE}
       }

--- a/repository/query-helpers.js
+++ b/repository/query-helpers.js
@@ -110,20 +110,9 @@ async function deleteResource(subject, graph, { inverse } = {}) {
   }
 }
 
-async function deleteSubjectWithPredicate(graph, subject, predicate) {
-  const deleteStatement = `
-  DELETE WHERE {
-    GRAPH <${graph}> {
-      ${sparqlEscapeUri(subject)} ${sparqlEscapeUri(predicate)} ?o .
-    }
-  }`;
-  await update(deleteStatement);
-}
-
 export {
   parseResult,
   countTriples,
   countResources,
   deleteResource,
-  deleteSubjectWithPredicate,
 }

--- a/repository/query-helpers.js
+++ b/repository/query-helpers.js
@@ -1,4 +1,4 @@
-import { sparqlEscapeUri } from 'mu';
+import { sparqlEscape, sparqlEscapeUri } from 'mu';
 import { querySudo as query, updateSudo as update } from './auth-sudo';
 import { MU_AUTH_PAGE_SIZE, VIRTUOSO_RESOURCE_PAGE_SIZE } from '../config';
 
@@ -22,10 +22,10 @@ function parseResult(result) {
   });
 };
 
-async function countTriples({ graph, subject = null, predicate = null, object = null }) {
+async function countTriples({ graph, subject = null, predicate = null, object = null, objectType = null }) {
   const subjectVar = subject ? `${sparqlEscapeUri(subject)}` : '?s';
   const predicateVar = predicate ? `${sparqlEscapeUri(predicate)}` : '?p';
-  const objectVar = object ? `${sparqlEscapeUri(object)}` : '?o';
+  const objectVar = object ? `${sparqlEscape(object, objectType ?? 'uri')}` : '?o';
   const queryResult = await query(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     SELECT (COUNT(*) as ?count)
@@ -62,48 +62,35 @@ async function countResources({ graph, type = null, lineage = null }) {
   return parseInt(queryResult.results.bindings[0].count.value);
 }
 
-async function deleteResource(subject, graph, { inverse } = {}) {
-  let count = 0;
-  let offset = 0;
-  let deleteStatement = null;
-  if (inverse) {
-    const object = subject;
-    count = await countTriples({ graph, object });
-    deleteStatement = `
-      DELETE {
-        GRAPH <${graph}> {
-          ?s ?p ${sparqlEscapeUri(object)} .
-        }
-      }
-      WHERE {
-        GRAPH <${graph}> {
-          SELECT ?s ?p
-            WHERE { ?s ?p ${sparqlEscapeUri(object)} . }
-            LIMIT ${MU_AUTH_PAGE_SIZE}
-        }
-      }
-    `;
-  } else {
-    count = await countTriples({ graph, subject });
-    // Note: no OFFSET needed in the subquery. Pagination is inherent since
-    // the WHERE clause doesn't match any longer for triples that are deleted
-    // in the previous batch.
-    deleteStatement = `
-      DELETE {
-        GRAPH <${graph}> {
-          ${sparqlEscapeUri(subject)} ?p ?o .
-        }
-      }
-      WHERE {
-        GRAPH <${graph}> {
-          SELECT ?p ?o
-            WHERE { ${sparqlEscapeUri(subject)} ?p ?o . }
-            LIMIT ${MU_AUTH_PAGE_SIZE}
-        }
-      }
-    `;
-  }
+async function deleteResource({ graph, type = null,  subject = null, predicate = null, object = null, objectType = null }) {
+  const subjectVar = subject ? `${sparqlEscapeUri(subject)}` : '?s';
+  const predicateVar = predicate ? `${sparqlEscapeUri(predicate)}` : '?p';
+  const objectVar = object ? `${sparqlEscape(object, objectType ?? 'uri')}` : '?o';
+  const typeStatement = type ? `${subjectVar} a <${type}> .` : '';
 
+  const count = await countTriples({ graph, subject, predicate, object, objectType });
+  let offset = 0;
+
+  // Note: no OFFSET needed in the subquery. Pagination is inherent since
+  // the WHERE clause doesn't match any longer for triples that are deleted
+  // in the previous batch.
+  const deleteStatement = `
+    DELETE {
+      GRAPH <${graph}> {
+        ${subjectVar} ${predicateVar} ${objectVar} .
+      }
+    }
+    WHERE {
+      GRAPH <${graph}> {
+        SELECT ?s ?p ?o
+          WHERE {
+            ${typeStatement}
+            ${subjectVar} ${predicateVar} ${objectVar} .
+          }
+          LIMIT ${MU_AUTH_PAGE_SIZE}
+      }
+    }
+  `;
   while (offset < count) {
     await update(deleteStatement);
     offset = offset + MU_AUTH_PAGE_SIZE;

--- a/repository/query-helpers.js
+++ b/repository/query-helpers.js
@@ -114,5 +114,5 @@ export {
   parseResult,
   countTriples,
   countResources,
-  deleteResource,
+  deleteResource
 }


### PR DESCRIPTION
Backend PR: https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/265
Frontend PR: https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1282

Adds filtering for privateComment triples so they don't get propagated to other graphs.

Function doing the filtering runs after all resources have been collected (so after the temp graph is full), then deletes the triples we want to filter out before continuing with propagation.

Filtering function is meant to be somewhat extensible. Currently the filtered out triples are defined in a map per type (so in this case, there's a filter for the type `besluit:Agendapunt`), and filters follow the syntax used by delta notifier resourceFormat v0.0.1.
Multiple filters can be added per type and more types can be added without having to alter the queries themselves. Can't combine filters though (although I doubt we'd need it, but it could be an interesting addition in the future).

Used the same batching technique that is used in the `collectResourceDetails() ` queries in case we end up having to delete a lot of triples.