### PR TITLE
Feature/kas 3360 aanpassen van vertrouwelijkheidstoggle op document niveau naar extra toegangsniveaus

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -7,6 +7,7 @@ const PUBLIC_GRAPH = 'http://mu.semte.ch/graphs/public';
 const AGENDA_TYPE = 'http://data.vlaanderen.be/ns/besluitvorming#Agenda';
 const DESIGN_AGENDA_STATUS = 'http://kanselarij.vo.data.gift/id/agendastatus/2735d084-63d1-499f-86f4-9b69eb33727f';
 
+const ACCESS_LEVEL_INTERNAL_SECRETARY = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/4bbbbc03-5dda-4885-a42f-7ee68fea1aae';
 const ACCESS_LEVEL_CABINET = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/d335f7e3-aefd-4f93-81a2-1629c2edafa3'; // intern regering
 const ACCESS_LEVEL_GOVERNMENT = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/abe4c18d-13a9-45f0-8cdd-c493eabbbe29'; // intern overheid
 const ACCESS_LEVEL_PUBLIC = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/6ca49d86-d40f-46c9-bde3-a322aa7e5c8e';
@@ -21,6 +22,7 @@ export {
   PUBLIC_GRAPH,
   AGENDA_TYPE,
   DESIGN_AGENDA_STATUS,
+  ACCESS_LEVEL_INTERNAL_SECRETARY,
   ACCESS_LEVEL_CABINET,
   ACCESS_LEVEL_GOVERNMENT,
   ACCESS_LEVEL_PUBLIC,

--- a/constants.js
+++ b/constants.js
@@ -7,7 +7,7 @@ const PUBLIC_GRAPH = 'http://mu.semte.ch/graphs/public';
 const AGENDA_TYPE = 'http://data.vlaanderen.be/ns/besluitvorming#Agenda';
 const DESIGN_AGENDA_STATUS = 'http://kanselarij.vo.data.gift/id/agendastatus/2735d084-63d1-499f-86f4-9b69eb33727f';
 
-const ACCESS_LEVEL_INTERNAL_SECRETARY = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/4bbbbc03-5dda-4885-a42f-7ee68fea1aae';
+const ACCESS_LEVEL_SECRETARY = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/4bbbbc03-5dda-4885-a42f-7ee68fea1aae'; // intern secretarie
 const ACCESS_LEVEL_CABINET = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/d335f7e3-aefd-4f93-81a2-1629c2edafa3'; // intern regering
 const ACCESS_LEVEL_GOVERNMENT = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/abe4c18d-13a9-45f0-8cdd-c493eabbbe29'; // intern overheid
 const ACCESS_LEVEL_PUBLIC = 'http://kanselarij.vo.data.gift/id/concept/toegangs-niveaus/6ca49d86-d40f-46c9-bde3-a322aa7e5c8e';
@@ -22,7 +22,7 @@ export {
   PUBLIC_GRAPH,
   AGENDA_TYPE,
   DESIGN_AGENDA_STATUS,
-  ACCESS_LEVEL_INTERNAL_SECRETARY,
+  ACCESS_LEVEL_SECRETARY,
   ACCESS_LEVEL_CABINET,
   ACCESS_LEVEL_GOVERNMENT,
   ACCESS_LEVEL_PUBLIC,

--- a/repository/collectors/document-collection.js
+++ b/repository/collectors/document-collection.js
@@ -18,7 +18,7 @@ import { decisionsReleaseFilter, documentsReleaseFilter } from './release-valida
  *
  * Some pieces are always visible, regardless of the documents/decision release
  *
- * Note, all pieces (dossier:Stuk) are copied. Restrictions regarding visibility (access level, confidentiality)
+ * Note, all pieces (dossier:Stuk) are copied. Restrictions regarding visibility (access level)
  * are only taken into account at the level of a file (nfo:FileDataObject)
  */
 async function collectReleasedDocuments(distributor) {

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -101,7 +101,7 @@ export default class CabinetDistributor extends Distributor {
   /*
    * Collect all files related to any of the previously copied released documents
    * that are accessible for the cabinet-profile
-   * I.e. the document is not confidential nor is it linked to any confidential subcase
+   * I.e. the document is not linked to any confidential subcase
   */
   async collectVisibleFiles() {
     const visibleFileQuery = `

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -1,7 +1,14 @@
 import Distributor from '../distributor';
 import { runStage } from '../timing';
 import { updateTriplestore } from '../triplestore';
-import { ADMIN_GRAPH, CABINET_GRAPH, AGENDA_TYPE } from '../../constants';
+import {
+  ADMIN_GRAPH,
+  CABINET_GRAPH,
+  ACCESS_LEVEL_CABINET,
+  ACCESS_LEVEL_GOVERNMENT,
+  ACCESS_LEVEL_PUBLIC,
+  AGENDA_TYPE,
+} from '../../constants';
 import { countResources } from '../query-helpers';
 import {
   collectReleasedAgendas,
@@ -113,10 +120,9 @@ export default class CabinetDistributor extends Distributor {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${this.sourceGraph}> {
-          ?piece ext:file ?file .
-          FILTER NOT EXISTS {
-            ?piece ext:vertrouwelijk "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
-          }
+          ?piece ext:file ?file ;
+                 ext:toegangsniveauVoorDocumentVersie ?accessLevel .
+          FILTER( ?accessLevel IN (<${ACCESS_LEVEL_CABINET}>, <${ACCESS_LEVEL_GOVERNMENT}>, <${ACCESS_LEVEL_PUBLIC}>) )
           FILTER NOT EXISTS {
             ?piece ^prov:generated / ext:indieningVindtPlaatsTijdens / dossier:doorloopt? ?subcase .
             ?subcase ext:vertrouwelijk "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -1,7 +1,14 @@
 import Distributor from '../distributor';
 import { runStage } from '../timing';
 import { updateTriplestore } from '../triplestore';
-import { ADMIN_GRAPH, GOVERNMENT_GRAPH, ACCESS_LEVEL_CABINET, AGENDA_TYPE } from '../../constants';
+import {
+  ADMIN_GRAPH,
+  GOVERNMENT_GRAPH,
+  ACCESS_LEVEL_CABINET,
+  ACCESS_LEVEL_GOVERNMENT,
+  ACCESS_LEVEL_PUBLIC,
+  AGENDA_TYPE,
+} from '../../constants';
 import { countResources } from '../query-helpers';
 import {
   collectReleasedAgendas,
@@ -122,10 +129,7 @@ export default class GovernmentDistributor extends Distributor {
         GRAPH <${this.sourceGraph}> {
           ?piece ext:file ?file ;
                  ext:toegangsniveauVoorDocumentVersie ?accessLevel .
-          FILTER( ?accessLevel != <${ACCESS_LEVEL_CABINET}> )
-          FILTER NOT EXISTS {
-            ?piece ext:vertrouwelijk "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
-          }
+          FILTER( ?accessLevel IN (<${ACCESS_LEVEL_GOVERNMENT}>, <${ACCESS_LEVEL_PUBLIC}>) )
           FILTER NOT EXISTS {
             ?piece ^prov:generated / ext:indieningVindtPlaatsTijdens / dossier:doorloopt? ?subcase .
             ?subcase ext:vertrouwelijk "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -102,9 +102,8 @@ export default class GovernmentDistributor extends Distributor {
   /*
    * Collect all files related to any of the previously copied released documents
    * that are accessible for the government-profile
-   * I.e. the document is not confidential, does have an access level
-   * different from 'Intern regering' (i.e. 'Intern overheid' or 'Publiek')
-   * and is not linked to a case that contains a confidential subcase.
+   * I.e. the document has an access level 'Intern overheid' or 'Publiek' and is
+   * not linked to a case that contains a confidential subcase.
    *
    * Note: some documents in legacy data don't have any access level and may not be
    * distributed. Therefore it's important to ensure the existence

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -1,7 +1,7 @@
 import Distributor from '../distributor';
 import { runStage } from '../timing';
 import { updateTriplestore } from '../triplestore';
-import { ADMIN_GRAPH, MINISTER_GRAPH, AGENDA_TYPE } from '../../constants';
+import { ADMIN_GRAPH, MINISTER_GRAPH, AGENDA_TYPE, ACCESS_LEVEL_INTERNAL_SECRETARY } from '../../constants';
 import { countResources } from '../query-helpers';
 import {
   collectReleasedAgendas,
@@ -114,7 +114,9 @@ export default class MinisterDistributor extends Distributor {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${this.sourceGraph}> {
-          ?piece ext:file ?file .
+          ?piece ext:file ?file ;
+                 ext:toegangsniveauVoorDocumentVersie ?accessLevel .
+          FILTER ( ?accessLevel != <${ACCESS_LEVEL_INTERNAL_SECRETARY}> )
         }
       }`;
     await updateTriplestore(visibleFileQuery);

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -1,7 +1,7 @@
 import Distributor from '../distributor';
 import { runStage } from '../timing';
 import { updateTriplestore } from '../triplestore';
-import { ADMIN_GRAPH, MINISTER_GRAPH, AGENDA_TYPE, ACCESS_LEVEL_INTERNAL_SECRETARY } from '../../constants';
+import { ADMIN_GRAPH, MINISTER_GRAPH, AGENDA_TYPE, ACCESS_LEVEL_SECRETARY } from '../../constants';
 import { countResources } from '../query-helpers';
 import {
   collectReleasedAgendas,
@@ -95,7 +95,7 @@ export default class MinisterDistributor extends Distributor {
   /*
    * Collect all files related to any of the previously copied released documents
    * that are accessible for the minister-profile
-   * I.e. no additional constraints apply. All documents are visible for the minister.
+   * I.e. the document does not have an access level 'Intern secretarie'.
   */
   async collectVisibleFiles() {
     const visibleFileQuery = `
@@ -116,7 +116,7 @@ export default class MinisterDistributor extends Distributor {
         GRAPH <${this.sourceGraph}> {
           ?piece ext:file ?file ;
                  ext:toegangsniveauVoorDocumentVersie ?accessLevel .
-          FILTER ( ?accessLevel != <${ACCESS_LEVEL_INTERNAL_SECRETARY}> )
+          FILTER ( ?accessLevel != <${ACCESS_LEVEL_SECRETARY}> )
         }
       }`;
     await updateTriplestore(visibleFileQuery);


### PR DESCRIPTION
Backend PR: https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/275

Only use access level to determine if a piece's visible file should be propagated (confidentiality is no longer a thing for pieces)