### PR TITLE
KAS-3552 Fix/early release documents existing cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Microservice propagating agenda data to graphs according to the authorization ru
 Add the following snippet to your `docker-compose.yml`:
 ```yml
   yggdrasil:
-    image: kanselarij/yggdrasil:5.6.0
+    image: kanselarij/yggdrasil:5.6.1
 ```
 
 Next, make the service listen for new delta messages. Assuming a delta-notifier is already available in the stack, add the following rules to the delta-notifier's configuration in `./config/delta/rules`.
@@ -130,5 +130,3 @@ In the initial load, the `Collectors` will get the data related to ALL agendas a
 
 
 The initial load can be configured by the environment variable `RELOAD_ON_INIT` flag. The initial load can be time consuming (+/- 40 min). You can find more details about the initial load here: [How to run the initial load](#how-to-run-the-initial-load)
-
-

--- a/repository/collectors/document-collection.js
+++ b/repository/collectors/document-collection.js
@@ -51,6 +51,7 @@ async function collectReleasedDocuments(distributor) {
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
         PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+        PREFIX dct: <http://purl.org/dc/terms/>
         INSERT {
           GRAPH <${distributor.tempGraph}> {
             ?piece a dossier:Stuk ;

--- a/repository/collectors/release-validations.js
+++ b/repository/collectors/release-validations.js
@@ -21,15 +21,17 @@ export function decisionsReleaseFilter(isEnabled) {
 
 export function documentsReleaseFilter(isEnabled) {
   if (isEnabled) {
-    // NOTE: we need the ?internalDocumentPublicationActivityUsed adms:status <http://themis.vlaanderen.be/id/concept/vrijgave-status/5da73f0d-6605-493c-9c1c-0d3a71bf286a> ("Planning bevestigd"@nl)
-    // to ensure we only filter on the confirmed publication activities, not the ones that were already executed, which would have status <http://themis.vlaanderen.be/id/concept/vrijgave-status/27bd25d1-72b4-49b2-a0ba-236ca28373e5> ("Vrijgegeven"@nl)
-    // If this filter were absent, it could cause documents associated with subcases in existing cases with other subcases that were previously published to be released as well.
+    // NOTE: we need the ?agenda dct:hasPart / besluitvorming:geagendeerdStuk ?piece to ensure we only propagate the documents for agendas that are relevant to these documents.
+    // If this filter were absent, it could cause documents associated with subcases in existing cases with other subcases that were previously published to be propagated as well.
+    // E.g., imagine creating a new subcase in an existing case, for which the earlier subcases were already released with an existing agenda at an earlier time.
+    // Any pieces added to the new subcase are linked to the existing parent case as well, causing the document release query to return results with a ?documentsReleaseDate in the past.
     return `
+      ?agenda dct:hasPart / besluitvorming:geagendeerdStuk ?piece .
       ?agenda
         besluitvorming:isAgendaVoor
-          / ^ext:internalDocumentPublicationActivityUsed ?internalDocumentPublicationActivity .
-      ?internalDocumentPublicationActivity prov:startedAtTime ?documentsReleaseDate ;
-          adms:status <http://themis.vlaanderen.be/id/concept/vrijgave-status/5da73f0d-6605-493c-9c1c-0d3a71bf286a> .
+          / ^ext:internalDocumentPublicationActivityUsed
+          / prov:startedAtTime
+        ?documentsReleaseDate .
       `;
   } else {
     return '';


### PR DESCRIPTION
This time this is a tested fix, working locally at least.

Confirmed through debugging that the filter with type `dossier:Dossier` always matched previously released agendas when documents are in the same case (dossier) in a new agenda https://github.com/kanselarij-vlaanderen/yggdrasil/blob/fdde3a7859c98dd550e0390fb6fca4e253f871a6/repository/collectors/document-collection.js#L35

This caused the documents associated with the new agenda to be released as well, which is not what we want.

I added a check that the `?piece` in the query is associated with the `?agenda` in the same query, thereby ensuring that only the relevant pieces are released when they are supposed to. https://github.com/kanselarij-vlaanderen/yggdrasil/blob/6b41b0134d9496d342891315ed6c247fb3629695/repository/collectors/release-validations.js#L29

Steps to reproduce the original issue:

1. Log in with a profile as Kanselarij
2. Create a new agenda
3. Search for a case (dossier) with existing documents, that were released as part of an earlier agenda
4. Add a new subcase (procedurestap) in this case (dossier)
5. Add a document to the new subcase and adjust its visibility to "Intern regering"
6. Add the subcase (procedurestap) to the new agenda you just created
7. Go to the agenda and formally approve all items
8. Approve the design agenda
9. Log in with a different profile, this time "Overheid"
10. After a while, yggdrasil should have propagated the approved agenda

BEFORE FIX: if you navigate as "Overheid" to the agenda item with the document, you would already be able to see it by clicking on "Documenten bekijken", even though it was not released yet.

AFTER FIX: if you navigate as "Overheid" to the agenda item with the document, you cannot see any documents yet, which is normal.