### PR TITLE
KAS-3549: Remove newsletter from meeting

### DIFF
--- a/model.js
+++ b/model.js
@@ -58,8 +58,7 @@ const pathsFromAgenda = {
     { source: 'agendaitemTreatment', predicate: 'besluitvorming:heeftBeslissing' }
   ],
   newsitem: [
-    { source: 'agendaitemTreatment', predicate: 'prov:generated' },
-    { source: 'meeting', predicate: 'ext:algemeneNieuwsbrief' }
+    { source: 'agendaitemTreatment', predicate: 'prov:generated' }
   ],
   piece: [
     { source: 'agendaitem', predicate: 'besluitvorming:geagendeerdStuk' },

--- a/repository/collectors/meeting-collection.js
+++ b/repository/collectors/meeting-collection.js
@@ -1,5 +1,4 @@
 import { updateTriplestore } from '../triplestore';
-import { decisionsReleaseFilter } from './release-validations';
 
 /**
  * Helpers to collect data about:
@@ -40,44 +39,6 @@ async function collectMeetings(distributor) {
   await updateTriplestore(relatedQuery);
 }
 
-/*
- * Collect related newsletters for the relevant meetings
- * from the distributor's source graph in the temp graph.
- *
- * If 'validateDecisionsRelease' is enabled on the distributor's release options
- * newsitems are only copied if the decisions of the meeting have already been released.
- */
-async function collectReleasedNewsletter(distributor) {
-  const properties = [
-    [ 'ext:algemeneNieuwsbrief' ], // newsletter
-  ];
-  const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
-
-  const relatedQuery = `
-      PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
-      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX prov: <http://www.w3.org/ns/prov#>
-
-      INSERT {
-        GRAPH <${distributor.tempGraph}> {
-          ?s a ?type ;
-             ext:tracesLineageTo ?agenda .
-        }
-      } WHERE {
-        GRAPH <${distributor.tempGraph}> {
-          ?meeting a besluit:Vergaderactiviteit ;
-              ext:tracesLineageTo ?agenda .
-        }
-        GRAPH <${distributor.sourceGraph}> {
-          ${decisionsReleaseFilter(distributor.releaseOptions.validateDecisionsRelease)}
-          ?meeting ${path} ?s .
-          ?s a ?type .
-        }
-      }`;
-  await updateTriplestore(relatedQuery);
-}
-
 async function collectPublicationActivities(distributor) {
   const properties = [
     [ '^ext:internalDecisionPublicationActivityUsed' ],
@@ -112,6 +73,5 @@ async function collectPublicationActivities(distributor) {
 
 export {
   collectMeetings,
-  collectReleasedNewsletter,
   collectPublicationActivities
 }

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -17,7 +17,6 @@ import {
 } from '../collectors/agenda-collection';
 import {
   collectMeetings,
-  collectReleasedNewsletter,
   collectPublicationActivities
 } from '../collectors/meeting-collection';
 import { collectSubcasesAndCases } from '../collectors/case-collection';
@@ -58,10 +57,6 @@ export default class CabinetDistributor extends Distributor {
       await runStage('Collect meeting and agendaitems', async () => {
         await collectMeetings(this);
         await collectReleasedAgendaitems(this);
-      }, this.constructor.name);
-
-      await runStage('Collect meeting newsletter', async () => {
-        await collectReleasedNewsletter(this);
       }, this.constructor.name);
 
       await runStage('Collect publication activities of meeting', async () => {

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -17,7 +17,6 @@ import {
 } from '../collectors/agenda-collection';
 import {
   collectMeetings,
-  collectReleasedNewsletter,
   collectPublicationActivities,
 } from '../collectors/meeting-collection';
 import { collectSubcasesAndCases } from '../collectors/case-collection';
@@ -59,10 +58,6 @@ export default class GovernmentDistributor extends Distributor {
       await runStage('Collect meeting and agendaitems', async () => {
         await collectMeetings(this);
         await collectReleasedAgendaitems(this);
-      }, this.constructor.name);
-
-      await runStage('Collect meeting newsletter', async () => {
-        await collectReleasedNewsletter(this);
       }, this.constructor.name);
 
       await runStage('Collect publication activities of meeting', async () => {

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -10,7 +10,6 @@ import {
 } from '../collectors/agenda-collection';
 import {
   collectMeetings,
-  collectReleasedNewsletter,
   collectPublicationActivities
 } from '../collectors/meeting-collection';
 import { collectSubcasesAndCases } from '../collectors/case-collection';
@@ -52,10 +51,6 @@ export default class MinisterDistributor extends Distributor {
       await runStage('Collect meeting and agendaitems', async () => {
         await collectMeetings(this);
         await collectReleasedAgendaitems(this);
-      }, this.constructor.name);
-
-      await runStage('Collect meeting newsletter', async () => {
-        await collectReleasedNewsletter(this);
       }, this.constructor.name);
 
       await runStage('Collect publication activities of meeting', async () => {


### PR DESCRIPTION
https://github.com/kanselarij-vlaanderen/frontend-kaleidos/pull/1437

Meetings no longer have a relation to newsletters, so the meeting-collector does not need to collect released newsletters and we no longer need to have a path from `meeting` to `newsitem`.