### PR TITLE
KAS-3653 add decision visibility by releasing for other profiles

### DIFF
--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -44,6 +44,11 @@ export default class CabinetDistributor extends Distributor {
     // Cabinets are allowed to see 'work in progress' on decisions and news-items
     // related to approved agendas. Hence, we don't validate on decision release date
     // and news-item release date
+
+    this.releaseOptions = {
+      validateDecisionsRelease: true,
+      validateDocumentsRelease: false
+    };
   }
 
   async collect(options) {

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -37,6 +37,11 @@ export default class MinisterDistributor extends Distributor {
     // Ministers are allowed to see 'work in progress' on decisions and news-items
     // related to approved agendas. Hence, we don't validate on decision release date
     // and news-item release date
+
+    this.releaseOptions = {
+      validateDecisionsRelease: true,
+      validateDocumentsRelease: false
+    };
   }
 
   async collect(options) {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-3653

Decision report and status should be hidden when decisions are not released yet for all profiles that are not admin/kanselarij.
Currently this was only for "intern-overheid" graph , but needs to be done the same for "minister" and "intern-regering" graph

Not 100% sure this is what's expected as we started from a ticket where the "postponed" decision result code should be hidden when not released.
further communication did not clearly specify if we should just restrict viewing any decision before release but seemed to indicate it.

