### PR TITLE
KAS-3658: Source file as main file

### DIFF
--- a/repository/collectors/document-collection.js
+++ b/repository/collectors/document-collection.js
@@ -142,6 +142,13 @@ async function collectPhysicalFiles(distributor) {
   await updateTriplestore(relatedQuery);
 }
 
+/*
+ * Collect all derived files related to the 'virtual' files
+ * from the distributor's source graph in the temp graph.
+ *
+ * Note, file visibility (access level) is checked
+ * at the level of the 'virtual' file.
+ */
 async function collectDerivedFiles(distributor) {
   const properties = [
     [ '^prov:hadPrimarySource' ], // derived-file (e.g. PDF file generated from a Word file)

--- a/repository/collectors/document-collection.js
+++ b/repository/collectors/document-collection.js
@@ -142,10 +142,10 @@ async function collectPhysicalFiles(distributor) {
   await updateTriplestore(relatedQuery);
 }
 
-async function collectPrimarySourceFiles(distributor) {
+async function collectDerivedFiles(distributor) {
   const properties = [
-    [ 'prov:hadPrimarySource' ], // source-file (e.g. Word file that PDF is generated from)
-    [ 'prov:hadPrimarySource', '^nie:dataSource' ], // physical-file of source-file
+    [ '^prov:hadPrimarySource' ], // derived-file (e.g. PDF file generated from a Word file)
+    [ '^prov:hadPrimarySource', '^nie:dataSource' ], // physical-file of derived-file
   ];
   const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
 
@@ -177,5 +177,5 @@ export {
   collectReleasedDocuments,
   collectDocumentContainers,
   collectPhysicalFiles,
-  collectPrimarySourceFiles,
+  collectDerivedFiles,
 }

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -28,7 +28,7 @@ import {
   collectReleasedDocuments,
   collectDocumentContainers,
   collectPhysicalFiles,
-  collectPrimarySourceFiles,
+  collectDerivedFiles,
 } from '../collectors/document-collection';
 
 /**
@@ -100,8 +100,8 @@ export default class CabinetDistributor extends Distributor {
         await collectPhysicalFiles(this);
       }, this.constructor.name);
 
-      await runStage('Collect primary source files', async() => {
-        await collectPrimarySourceFiles(this);
+      await runStage('Collect derived files', async() => {
+        await collectDerivedFiles(this);
       }, this.constructor.name);
     }
 

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -130,7 +130,7 @@ export default class CabinetDistributor extends Distributor {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${this.sourceGraph}> {
-          ?piece ext:file ?file ;
+          ?piece prov:value ?file ;
                  ext:toegangsniveauVoorDocumentVersie ?accessLevel .
           FILTER( ?accessLevel IN (<${ACCESS_LEVEL_CABINET}>, <${ACCESS_LEVEL_GOVERNMENT}>, <${ACCESS_LEVEL_PUBLIC}>) )
         }

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -131,7 +131,7 @@ export default class GovernmentDistributor extends Distributor {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${this.sourceGraph}> {
-          ?piece ext:file ?file ;
+          ?piece prov:value ?file ;
                  ext:toegangsniveauVoorDocumentVersie ?accessLevel .
           FILTER( ?accessLevel IN (<${ACCESS_LEVEL_GOVERNMENT}>, <${ACCESS_LEVEL_PUBLIC}>) )
         }

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -28,7 +28,7 @@ import {
   collectReleasedDocuments,
   collectDocumentContainers,
   collectPhysicalFiles,
-  collectPrimarySourceFiles,
+  collectDerivedFiles,
 } from '../collectors/document-collection';
 
 /**
@@ -96,8 +96,8 @@ export default class GovernmentDistributor extends Distributor {
         await collectPhysicalFiles(this);
       }, this.constructor.name);
 
-      await runStage('Collect primary source files', async() => {
-        await collectPrimarySourceFiles(this);
+      await runStage('Collect derived files', async() => {
+        await collectDerivedFiles(this);
       }, this.constructor.name);
     }
 

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -124,7 +124,7 @@ export default class MinisterDistributor extends Distributor {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${this.sourceGraph}> {
-          ?piece ext:file ?file ;
+          ?piece prov:value ?file ;
                  ext:toegangsniveauVoorDocumentVersie ?accessLevel .
           FILTER ( ?accessLevel != <${ACCESS_LEVEL_SECRETARY}> )
         }

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -21,7 +21,7 @@ import {
   collectReleasedDocuments,
   collectDocumentContainers,
   collectPhysicalFiles,
-  collectPrimarySourceFiles
+  collectDerivedFiles,
 } from '../collectors/document-collection';
 
 /**
@@ -94,8 +94,8 @@ export default class MinisterDistributor extends Distributor {
         await collectPhysicalFiles(this);
       }, this.constructor.name);
 
-      await runStage('Collect primary source files', async() => {
-        await collectPrimarySourceFiles(this);
+      await runStage('Collect derived files', async() => {
+        await collectDerivedFiles(this);
       }, this.constructor.name);
     }
 


### PR DESCRIPTION
- Renames the collector function from `collectPrimarySourceFiles` to `collectDerivedFiles`, since that's what we're doing now
- Replaces the predicate between `piece` and `file`