### PR TITLE
KAS-3664: Predicate migrations

### DIFF
--- a/model.js
+++ b/model.js
@@ -56,7 +56,7 @@ const pathsFromAgenda = {
     { source: 'decisionmakingFlow', predicate: '^dossier:Dossier.isNeerslagVan' }
   ],
   agendaitemTreatment: [
-    { source: 'agendaitem', predicate: '^besluitvorming:heeftOnderwerp' }
+    { source: 'agendaitem', predicate: '^dct:subject' }
   ],
   decisionActivity: [
     { source: 'agendaitemTreatment', predicate: 'besluitvorming:heeftBeslissing' }

--- a/model.js
+++ b/model.js
@@ -78,7 +78,7 @@ const pathsFromAgenda = {
     { source: 'meeting', predicate: 'dossier:genereert' }
   ],
   documentContainer: [
-    { source: 'piece', predicate: '^dossier:collectie.bestaatUit' }
+    { source: 'piece', predicate: '^dossier:Collectie.bestaatUit' }
   ]
 };
 

--- a/repository/collectors/decision-collection.js
+++ b/repository/collectors/decision-collection.js
@@ -18,15 +18,15 @@ import { decisionsReleaseFilter } from './release-validations';
  */
 async function collectReleasedAgendaitemTreatments(distributor) {
   const properties = [
-    [ '^besluitvorming:heeftOnderwerp' ] // agendaitem-treatment
+    [ '^dct:subject' ] // agendaitem-treatment
   ];
   const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
 
   const relatedQuery = `
-      PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
       PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX dct: <http://purl.org/dc/terms/>
 
       INSERT {
         GRAPH <${distributor.tempGraph}> {

--- a/repository/collectors/decision-collection.js
+++ b/repository/collectors/decision-collection.js
@@ -23,6 +23,7 @@ async function collectReleasedAgendaitemTreatments(distributor) {
   const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
 
   const relatedQuery = `
+      PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
       PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX prov: <http://www.w3.org/ns/prov#>

--- a/repository/collectors/document-collection.js
+++ b/repository/collectors/document-collection.js
@@ -78,7 +78,7 @@ async function collectReleasedDocuments(distributor) {
  */
 async function collectDocumentContainers(distributor) {
   const properties = [
-    [ '^dossier:collectie.bestaatUit' ], // document-container
+    [ '^dossier:Collectie.bestaatUit' ], // document-container
   ];
   const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
 

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -226,11 +226,11 @@ class Distributor {
     let offset = 0;
     const summary = await queryTriplestore(`
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-    PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+    PREFIX dct: <http://purl.org/dc/terms/>
     SELECT (COUNT(?s) AS ?count) WHERE {
       GRAPH <${this.tempGraph}> {
         ?s a besluit:Agendapunt .
-        ?o besluitvorming:heeftOnderwerp ?s .
+        ?o dct:subject ?s .
         FILTER NOT EXISTS { ?o a besluit:BehandelingVanAgendapunt .}
       }
     }`);
@@ -238,17 +238,17 @@ class Distributor {
 
     const deleteStatement =`
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-    PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
+    PREFIX dct: <http://purl.org/dc/terms/>
     DELETE {
       GRAPH <${this.tempGraph}> {
-        ?o besluitvorming:heeftOnderwerp ?s .
+        ?o dct:subject ?s .
       }
     }
     WHERE {
       GRAPH <${this.tempGraph}> {
         SELECT ?s ?o {
           ?s a besluit:Agendapunt .
-          ?o besluitvorming:heeftOnderwerp ?s .
+          ?o dct:subject ?s .
           FILTER NOT EXISTS { ?o a besluit:BehandelingVanAgendapunt .}
         }
         LIMIT ${MU_AUTH_PAGE_SIZE}

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -119,6 +119,7 @@ export default class CabinetDistributor extends Distributor {
       PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+      PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
       INSERT {
         GRAPH <${this.tempGraph}> {
           ?file a nfo:FileDataObject ;
@@ -131,7 +132,7 @@ export default class CabinetDistributor extends Distributor {
         }
         GRAPH <${this.sourceGraph}> {
           ?piece ext:file ?file ;
-                 ext:toegangsniveauVoorDocumentVersie ?accessLevel .
+                 besluitvorming:vertrouwelijkheidsniveau ?accessLevel .
           FILTER( ?accessLevel IN (<${ACCESS_LEVEL_CABINET}>, <${ACCESS_LEVEL_GOVERNMENT}>, <${ACCESS_LEVEL_PUBLIC}>) )
         }
       }`;

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -112,7 +112,7 @@ export default class GovernmentDistributor extends Distributor {
    *
    * Note: some documents in legacy data don't have any access level and may not be
    * distributed. Therefore it's important to ensure the existence
-   * of the triple `?piece ext:toegangsniveauVoorDocumentVersie ?any`.
+   * of the triple `?piece besluitvorming:vertrouwelijkheidsniveau ?any`.
   */
   async collectVisibleFiles() {
     const visibleFileQuery = `
@@ -120,6 +120,7 @@ export default class GovernmentDistributor extends Distributor {
       PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+      PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
       INSERT {
         GRAPH <${this.tempGraph}> {
           ?file a nfo:FileDataObject ;
@@ -132,7 +133,7 @@ export default class GovernmentDistributor extends Distributor {
         }
         GRAPH <${this.sourceGraph}> {
           ?piece ext:file ?file ;
-                 ext:toegangsniveauVoorDocumentVersie ?accessLevel .
+                 besluitvorming:vertrouwelijkheidsniveau ?accessLevel .
           FILTER( ?accessLevel IN (<${ACCESS_LEVEL_GOVERNMENT}>, <${ACCESS_LEVEL_PUBLIC}>) )
         }
       }`;

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -113,6 +113,7 @@ export default class MinisterDistributor extends Distributor {
       PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+      PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
       INSERT {
         GRAPH <${this.tempGraph}> {
           ?file a nfo:FileDataObject ;
@@ -125,7 +126,7 @@ export default class MinisterDistributor extends Distributor {
         }
         GRAPH <${this.sourceGraph}> {
           ?piece ext:file ?file ;
-                 ext:toegangsniveauVoorDocumentVersie ?accessLevel .
+                 besluitvorming:vertrouwelijkheidsniveau ?accessLevel .
           FILTER ( ?accessLevel != <${ACCESS_LEVEL_SECRETARY}> )
         }
       }`;


### PR DESCRIPTION
Replaces two predicates:
- `ext:toegangsniveauVoorDocumentVersie` → `besluitvorming:vertrouwelijkheidsniveau`
- `besluitvorming:heeftOnderwerp` → `dct:subject`
- `dossier:collectie.bestaatUit` → `dossier:Collectie.bestaatUit`

Requires version bumps in:
- [ ] https://github.com/kanselarij-vlaanderen/app-kaleidos