### PR TITLE
KAS-4081 Added document collector rule for signed pieces

### DIFF
--- a/repository/collectors/document-collection.js
+++ b/repository/collectors/document-collection.js
@@ -41,7 +41,8 @@ async function collectReleasedDocuments(distributor) {
     { type: 'besluit:Agendapunt', predicate: 'ext:bevatReedsBezorgdAgendapuntDocumentversie' },
     { type: 'dossier:Procedurestap', predicate: 'ext:bevatReedsBezorgdeDocumentversie' },
     { type: 'besluit:Vergaderactiviteit', predicate: 'ext:zittingDocumentversie' },
-    { type: 'besluit:Vergaderactiviteit', predicate: 'dossier:genereert' }
+    { type: 'besluit:Vergaderactiviteit', predicate: 'dossier:genereert' },
+    { type: 'dossier:Stuk', predicate: '^sign:ongetekendStuk' }
   ];
 
   for (let path of releasedPiecePaths) {
@@ -52,6 +53,8 @@ async function collectReleasedDocuments(distributor) {
         PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
         PREFIX dct: <http://purl.org/dc/terms/>
+        PREFIX sign: <http://mu.semte.ch/vocabularies/ext/handtekenen/>
+
         INSERT {
           GRAPH <${distributor.tempGraph}> {
             ?piece a dossier:Stuk ;
@@ -68,6 +71,10 @@ async function collectReleasedDocuments(distributor) {
             ?piece a dossier:Stuk .
           }
         }`;
+    if (path.predicate === '^sign:ongetekendStuk') {
+      console.log('***********');
+      console.log(releasedDocumentsQuery);
+    }
     await updateTriplestore(releasedDocumentsQuery);
   }
 }


### PR DESCRIPTION
To be properly tested after https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/380 has been merged.

Tested locally to see that nothing breaks, but obviously I don't have any signed pieces at the moment.