### PR TITLE
Feature/kas 111 beslissingsfiche klaarmaken voor digitaal ondertekenen

### DIFF
--- a/model.js
+++ b/model.js
@@ -80,7 +80,8 @@ const pathsFromAgenda = {
     { source: 'case', predicate: 'dossier:Dossier.bestaatUit' },
     { source: 'subcase', predicate: 'ext:bevatReedsBezorgdeDocumentversie' },
     { source: 'meeting', predicate: 'ext:zittingDocumentversie' },
-    { source: 'meeting', predicate: 'dossier:genereert' }
+    { source: 'meeting', predicate: 'dossier:genereert' },
+    { source: 'meeting', predicate: 'besluitvorming:heeftNotulen' },
   ],
   signedPiece: [
     { source: 'piece', predicate: '^sign:ongetekendStuk' }

--- a/repository/collectors/document-collection.js
+++ b/repository/collectors/document-collection.js
@@ -42,6 +42,7 @@ async function collectReleasedDocuments(distributor) {
     { type: 'dossier:Procedurestap', predicate: 'ext:bevatReedsBezorgdeDocumentversie' },
     { type: 'besluit:Vergaderactiviteit', predicate: 'ext:zittingDocumentversie' },
     { type: 'besluit:Vergaderactiviteit', predicate: 'dossier:genereert' },
+    { type: 'besluit:Vergaderactiviteit', predicate: 'besluitvorming:heeftNotulen' },
 
     // pieces that have been signed, requires other pieces
     { type: 'dossier:Stuk', predicate: '^sign:ongetekendStuk' },


### PR DESCRIPTION
Propagates meeting minutes by default (as was the case before, as all pieces linked to meeting are immediately propagated). To prevent users reading in-progress meeting minutes, the frontend defaults the minutes' access level to Intern Secretarie, so other users will only be able to read the actual PDF once the secretarie decides it's finished.