### PR TITLE
Feature/kas 4322 pub search for all

### DIFF
--- a/model.js
+++ b/model.js
@@ -6,6 +6,8 @@ const prefixes = {
   'dossier': 'https://data.vlaanderen.be/ns/dossier#',
   'prov': 'http://www.w3.org/ns/prov#',
   'sign': 'http://mu.semte.ch/vocabularies/ext/handtekenen/',
+  'pub': 'http://mu.semte.ch/vocabularies/ext/publicatie/',
+  'adms': 'http://www.w3.org/ns/adms#',
 };
 
 const typeUris = [
@@ -20,6 +22,8 @@ const typeUris = [
   { key: 'subcase', uri: 'dossier:Procedurestap' },
   { key: 'case', uri: 'dossier:Dossier' },
   { key: 'decisionmakingFlow', uri: 'besluitvorming:Besluitvormingsaangelegenheid' },
+  { key: 'publicationFlow', uri: 'pub:Publicatieaangelegenheid' },
+  { key: 'identification', uri: 'adms:Identifier' },
   { key: 'agendaitemTreatment', uri: 'besluit:BehandelingVanAgendapunt' },
   { key: 'decisionActivity', uri: 'besluitvorming:Beslissingsactiviteit' },
   { key: 'newsitem', uri: 'ext:Nieuwsbericht' },
@@ -60,6 +64,12 @@ const pathsFromAgenda = {
   ],
   case: [
     { source: 'decisionmakingFlow', predicate: '^dossier:Dossier.isNeerslagVan' }
+  ],
+  publicationFlow: [
+    { source: 'case', predicate: '^dossier:behandelt' }
+  ],
+  identification: [
+    { source: 'publicationFlow', predicate: 'adms:identifier' }
   ],
   agendaitemTreatment: [
     { source: 'agendaitem', predicate: '^dct:subject' }

--- a/model.js
+++ b/model.js
@@ -65,12 +65,6 @@ const pathsFromAgenda = {
   case: [
     { source: 'decisionmakingFlow', predicate: '^dossier:Dossier.isNeerslagVan' }
   ],
-  publicationFlow: [
-    { source: 'case', predicate: '^dossier:behandelt' }
-  ],
-  identification: [
-    { source: 'publicationFlow', predicate: 'adms:identifier' }
-  ],
   agendaitemTreatment: [
     { source: 'agendaitem', predicate: '^dct:subject' }
   ],
@@ -98,7 +92,13 @@ const pathsFromAgenda = {
   ],
   documentContainer: [
     { source: 'piece', predicate: '^dossier:Collectie.bestaatUit' }
-  ]
+  ],
+  publicationFlow: [
+    { source: 'piece', predicate: '^pub:referentieDocument' }
+  ],
+  identification: [
+    { source: 'publicationFlow', predicate: 'adms:identifier' }
+  ],
 };
 
 export {

--- a/repository/collectors/publication-collection.js
+++ b/repository/collectors/publication-collection.js
@@ -1,0 +1,54 @@
+import { updateTriplestore } from '../triplestore';
+import { decisionsReleaseFilter } from './release-validations';
+
+/**
+ * Helpers to collect data about:
+ * - publication-flows
+ * - identification
+ */
+
+/*
+ * Collect certain specific attributes of publication flows and their
+ * identifiers related to the agendaitems from the distributor's source graph
+ * in the temp graph.
+ */
+async function collectPublicationFlows(distributor) {
+  const decisionsFilter = decisionsReleaseFilter(true);
+
+  const pathToPubFlow = [ '^besluitvorming:genereertAgendapunt', 'besluitvorming:vindtPlaatsTijdens', '^dossier:doorloopt', '^dossier:Dossier.isNeerslagVan', '^dossier:behandelt' ];
+  const properties = [
+    pathToPubFlow, // publication-flow
+    [ ...pathToPubFlow, 'adms:identifier' ] // identification
+  ];
+  const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
+
+  const relatedQuery = `
+      PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+      PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
+      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX adms: <http://www.w3.org/ns/adms#>
+
+      INSERT {
+        GRAPH <${distributor.tempGraph}> {
+          ?s a ?type ;
+             ext:tracesLineageTo ?agenda .
+        }
+      } WHERE {
+        GRAPH <${distributor.tempGraph}> {
+          ?agendaitem a besluit:Agendapunt ;
+              ext:tracesLineageTo ?agenda .
+        }
+        GRAPH <${distributor.sourceGraph}> {
+          ${decisionsFilter}
+          ?agendaitem ${path} ?s .
+          ?s a ?type .
+        }
+      }`;
+  await updateTriplestore(relatedQuery);
+}
+
+export {
+  collectPublicationFlows,
+}

--- a/repository/collectors/publication-collection.js
+++ b/repository/collectors/publication-collection.js
@@ -5,30 +5,35 @@ import { decisionsReleaseFilter } from './release-validations';
  * Helpers to collect data about:
  * - publication-flows
  * - identification
+ *
+ * Collection happens via the piece not the agendaitem!
  */
 
 /*
  * Collect certain specific attributes of publication flows and their
- * identifiers related to the agendaitems from the distributor's source graph
+ * identifiers related to the pieces from the distributor's source graph
  * in the temp graph.
+ *
+ * The piece collection must have already happened for this collection to
+ * generate results. The filter to check if decisions have been released is
+ * always applied.
  */
 async function collectPublicationFlows(distributor) {
   const decisionsFilter = decisionsReleaseFilter(true);
 
-  const pathToPubFlow = [ '^besluitvorming:genereertAgendapunt', 'besluitvorming:vindtPlaatsTijdens', '^dossier:doorloopt', '^dossier:Dossier.isNeerslagVan', '^dossier:behandelt' ];
   const properties = [
-    pathToPubFlow, // publication-flow
-    [ ...pathToPubFlow, 'adms:identifier' ] // identification
+    [ '^pub:referentieDocument' ], // publication-flow
+    [ '^pub:referentieDocument', 'adms:identifier' ] // identification
   ];
   const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
 
   const relatedQuery = `
-      PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
-      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-      PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+      PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
       PREFIX adms: <http://www.w3.org/ns/adms#>
+      PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
 
       INSERT {
         GRAPH <${distributor.tempGraph}> {
@@ -37,12 +42,12 @@ async function collectPublicationFlows(distributor) {
         }
       } WHERE {
         GRAPH <${distributor.tempGraph}> {
-          ?agendaitem a besluit:Agendapunt ;
+          ?piece a dossier:Stuk ;
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
           ${decisionsFilter}
-          ?agendaitem ${path} ?s .
+          ?piece ${path} ?s .
           ?s a ?type .
         }
       }`;

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -267,7 +267,6 @@ class Distributor {
         UNION { ?s pub:doorlooptVertaling ?o }
         UNION { ?s pub:doorlooptPublicatie ?o }
         UNION { ?s prov:qualifiedDelegation ?o }
-        UNION { ?s pub:beleidsveld ?o }
         UNION { ?s dct:created ?o }
       }
     }`);
@@ -303,7 +302,6 @@ class Distributor {
             pub:doorlooptVertaling
             pub:doorlooptPublicatie
             prov:qualifiedDelegation
-            pub:beleidsveld
             dct:created
           }
           ?s a pub:Publicatieaangelegenheid .

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -244,7 +244,6 @@ class Distributor {
     let offset = 0;
     const summary = await queryTriplestore(`
     PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
-    PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX fabio: <http://purl.org/spar/fabio/>
     PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
@@ -267,7 +266,6 @@ class Distributor {
         UNION { ?s pub:doorlooptVertaling ?o }
         UNION { ?s pub:doorlooptPublicatie ?o }
         UNION { ?s prov:qualifiedDelegation ?o }
-        UNION { ?s dct:subject ?o }
         UNION { ?s pub:beleidsveld ?o }
       }
     }`);
@@ -275,7 +273,6 @@ class Distributor {
 
     const deleteStatement =`
     PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
-    PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX fabio: <http://purl.org/spar/fabio/>
     PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
@@ -303,7 +300,6 @@ class Distributor {
             pub:doorlooptVertaling
             pub:doorlooptPublicatie
             prov:qualifiedDelegation
-            dct:subject
             pub:beleidsveld
           }
           ?s a pub:Publicatieaangelegenheid .

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -244,6 +244,7 @@ class Distributor {
     let offset = 0;
     const summary = await queryTriplestore(`
     PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+    PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX fabio: <http://purl.org/spar/fabio/>
     PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
@@ -267,12 +268,14 @@ class Distributor {
         UNION { ?s pub:doorlooptPublicatie ?o }
         UNION { ?s prov:qualifiedDelegation ?o }
         UNION { ?s pub:beleidsveld ?o }
+        UNION { ?s dct:created ?o }
       }
     }`);
     const count = summary.results.bindings.map(b => b['count'].value);
 
     const deleteStatement =`
     PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
+    PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX fabio: <http://purl.org/spar/fabio/>
     PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
@@ -301,6 +304,7 @@ class Distributor {
             pub:doorlooptPublicatie
             prov:qualifiedDelegation
             pub:beleidsveld
+            dct:created
           }
           ?s a pub:Publicatieaangelegenheid .
           OPTIONAL { ?s ?p ?o }

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -78,10 +78,6 @@ export default class CabinetDistributor extends Distributor {
         await collectCasesSubcasesAndDecisionmakingFlows(this);
       }, this.constructor.name);
 
-      await runStage('Collect publication-flows', async() => {
-        await collectPublicationFlows(this);
-      }, this.constructor.name);
-
       await runStage('Collect released agenda-item treatments', async () => {
         await collectReleasedAgendaitemTreatments(this);
       }, this.constructor.name);
@@ -108,6 +104,10 @@ export default class CabinetDistributor extends Distributor {
 
       await runStage('Collect derived files', async() => {
         await collectDerivedFiles(this);
+      }, this.constructor.name);
+
+      await runStage('Collect publication-flows', async() => {
+        await collectPublicationFlows(this);
       }, this.constructor.name);
     }
 

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -31,6 +31,7 @@ import {
   collectPhysicalFiles,
   collectDerivedFiles,
 } from '../collectors/document-collection';
+import { collectPublicationFlows } from '../collectors/publication-collection';
 
 /**
  * Distributor for cabinet (intern-regering) profile
@@ -75,6 +76,10 @@ export default class CabinetDistributor extends Distributor {
 
       await runStage('Collect subcases and cases', async () => {
         await collectCasesSubcasesAndDecisionmakingFlows(this);
+      }, this.constructor.name);
+
+      await runStage('Collect publication-flows', async() => {
+        await collectPublicationFlows(this);
       }, this.constructor.name);
 
       await runStage('Collect released agenda-item treatments', async () => {

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -30,6 +30,7 @@ import {
   collectPhysicalFiles,
   collectDerivedFiles,
 } from '../collectors/document-collection';
+import { collectPublicationFlows } from '../collectors/publication-collection';
 
 /**
  * Distributor for government (intern-overheid) profile
@@ -74,6 +75,10 @@ export default class GovernmentDistributor extends Distributor {
 
       await runStage('Collect subcases and cases', async () => {
         await collectCasesSubcasesAndDecisionmakingFlows(this);
+      }, this.constructor.name);
+
+      await runStage('Collect publication-flows', async() => {
+        await collectPublicationFlows(this);
       }, this.constructor.name);
 
       await runStage('Collect released agenda-item treatments', async () => {

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -77,10 +77,6 @@ export default class GovernmentDistributor extends Distributor {
         await collectCasesSubcasesAndDecisionmakingFlows(this);
       }, this.constructor.name);
 
-      await runStage('Collect publication-flows', async() => {
-        await collectPublicationFlows(this);
-      }, this.constructor.name);
-
       await runStage('Collect released agenda-item treatments', async () => {
         await collectReleasedAgendaitemTreatments(this);
       }, this.constructor.name);
@@ -107,6 +103,10 @@ export default class GovernmentDistributor extends Distributor {
 
       await runStage('Collect derived files', async() => {
         await collectDerivedFiles(this);
+      }, this.constructor.name);
+
+      await runStage('Collect publication-flows', async() => {
+        await collectPublicationFlows(this);
       }, this.constructor.name);
     }
 

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -72,10 +72,6 @@ export default class MinisterDistributor extends Distributor {
         await collectCasesSubcasesAndDecisionmakingFlows(this);
       }, this.constructor.name);
 
-      await runStage('Collect publication-flows', async() => {
-        await collectPublicationFlows(this);
-      }, this.constructor.name);
-
       await runStage('Collect released agenda-item treatments', async () => {
         await collectReleasedAgendaitemTreatments(this);
       }, this.constructor.name);
@@ -102,6 +98,10 @@ export default class MinisterDistributor extends Distributor {
 
       await runStage('Collect derived files', async() => {
         await collectDerivedFiles(this);
+      }, this.constructor.name);
+
+      await runStage('Collect publication-flows', async() => {
+        await collectPublicationFlows(this);
       }, this.constructor.name);
     }
 

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -24,6 +24,7 @@ import {
   collectPhysicalFiles,
   collectDerivedFiles,
 } from '../collectors/document-collection';
+import { collectPublicationFlows } from '../collectors/publication-collection';
 
 /**
  * Distributor for minister profile
@@ -69,6 +70,10 @@ export default class MinisterDistributor extends Distributor {
 
       await runStage('Collect subcases and cases', async () => {
         await collectCasesSubcasesAndDecisionmakingFlows(this);
+      }, this.constructor.name);
+
+      await runStage('Collect publication-flows', async() => {
+        await collectPublicationFlows(this);
       }, this.constructor.name);
 
       await runStage('Collect released agenda-item treatments', async () => {


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4322

Expands Yggdrasil so that it can propagate publication flows to all profiles.

Pub flows are gathered via pieces (as opposed to agendaitems), this way we should only propagate publication flows that are visible by users (i.e. because the only way they have to know a pub flow exists is by seeing the pub flow ID pill in the document-card).