### PR TITLE
Simplify subquery for collecting resources for distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following environment variables can be optionally configured:
 |`NB_OF_QUERY_RETRIES`      | 6                   | Number of times a failed query will be retried. Only applicable to direct queries.
 |`RETRY_TIMEOUT_MS`         | 1000                | Query timeout (ms). Only applicable to direct queries.
 |`DELTA_INTERVAL_MS`        | 60000               | Time to wait before starting the next data propagation (ms) when the first delta arrives. This allows to collect multiple delta messages in 1 propagation process. |
+|`VIRTUOSO_RESOURCE_PAGE_SIZE` | 10000                | The number of triples selected in the subquery (= VIRTUOSO_RESOURCE_PAGE_SIZE * triples_for_resource). should not exceed the maximum number of triples returned by the database. (ie. ResultSetMaxRows in Virtuoso). |
 
 Logging can be enabled or disabled on different levels, using `true` or `false`
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following environment variables can be optionally configured:
 |`NB_OF_QUERY_RETRIES`      | 6                   | Number of times a failed query will be retried. Only applicable to direct queries.
 |`RETRY_TIMEOUT_MS`         | 1000                | Query timeout (ms). Only applicable to direct queries.
 |`DELTA_INTERVAL_MS`        | 60000               | Time to wait before starting the next data propagation (ms) when the first delta arrives. This allows to collect multiple delta messages in 1 propagation process. |
-|`VIRTUOSO_RESOURCE_PAGE_SIZE` | 10000                | The number of triples selected in the subquery (= VIRTUOSO_RESOURCE_PAGE_SIZE * triples_for_resource). should not exceed the maximum number of triples returned by the database. (ie. ResultSetMaxRows in Virtuoso). |
+|`VIRTUOSO_RESOURCE_PAGE_SIZE` | 10000                | The number of triples selected in the subquery (= VIRTUOSO_RESOURCE_PAGE_SIZE * triples_for_resource). should not exceed the maximum number of triples returned by the database. (ie. ResultSetMaxRows in Virtuoso). Should also not exceed the maximum number of rows sorted. (ie MaxSortedTopRows in virtuoso) |
 
 Logging can be enabled or disabled on different levels, using `true` or `false`
 

--- a/config.js
+++ b/config.js
@@ -20,7 +20,7 @@ if (isTruthy(process.env.RELOAD_ON_INIT)) {
 }
 
 const MU_AUTH_PAGE_SIZE = parseInt(process.env.MU_AUTH_PAGE_SIZE || '2500');
-const VIRTUOSO_RESOURCE_PAGE_SIZE = parseInt(process.env.VIRTUOSO_RESOURCE_PAGE_SIZE || '25000');
+const VIRTUOSO_RESOURCE_PAGE_SIZE = parseInt(process.env.VIRTUOSO_RESOURCE_PAGE_SIZE || '10000');
 const VALUES_BLOCK_SIZE = parseInt(process.env.VALUES_BLOCK_SIZE || '100');
 
 function isTruthy(value) {

--- a/repository/collectors/agenda-collection.js
+++ b/repository/collectors/agenda-collection.js
@@ -98,6 +98,7 @@ async function collectReleasedAgendaitems(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?agenda a besluitvorming:Agenda .
           ?agenda dct:hasPart ?s .
           ?s a besluit:Agendapunt .
         }
@@ -132,6 +133,7 @@ async function collectAgendaitemActivities(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?agendaitem a besluit:Agendapunt .
           ?agendaitem ${path} ?s .
           ?s a ?type .
         }
@@ -160,6 +162,7 @@ async function collectAgendaStatusActivities(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?agenda a besluitvorming:Agenda .
           ?s prov:used ?agenda .
           ?s a ext:AgendaStatusActivity .
         }

--- a/repository/collectors/case-collection.js
+++ b/repository/collectors/case-collection.js
@@ -40,6 +40,7 @@ async function collectCasesSubcasesAndDecisionmakingFlows(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?agendaitem a besluit:Agendapunt .
           ?agendaitem ${path} ?s .
           ?s a ?type .
         }

--- a/repository/collectors/decision-collection.js
+++ b/repository/collectors/decision-collection.js
@@ -41,6 +41,7 @@ async function collectReleasedAgendaitemTreatments(distributor) {
         }
         GRAPH <${distributor.sourceGraph}> {
           ${decisionsReleaseFilter(distributor.releaseOptions.validateDecisionsRelease)}
+          ?agendaitem a besluit:Agendapunt .
           ?agendaitem ${path} ?s .
           ?s a ?type .
         }
@@ -79,6 +80,7 @@ async function collectAgendaitemDecisionActivitiesAndNewsitems(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?treatment a besluit:BehandelingVanAgendapunt .
           ?treatment ${path} ?s .
           ?s a ?type .
         }

--- a/repository/collectors/document-collection.js
+++ b/repository/collectors/document-collection.js
@@ -80,6 +80,7 @@ async function collectReleasedDocuments(distributor) {
           }
           GRAPH <${distributor.sourceGraph}> {
             ${path.filter ? path.filter : ''}
+            ?s a ${path.type} .
             ?s ${path.predicate} ?piece .
             ?piece a dossier:Stuk .
           }
@@ -114,6 +115,7 @@ async function collectDocumentContainers(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?piece a dossier:Stuk .
           ?piece ${path} ?s .
           ?s a ?type .
         }
@@ -151,6 +153,7 @@ async function collectPhysicalFiles(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?virtualFile a nfo:FileDataObject .
           ?virtualFile ${path} ?s .
           ?s a ?type .
         }
@@ -189,6 +192,7 @@ async function collectDerivedFiles(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?virtualFile a nfo:FileDataObject .
           ?virtualFile ${path} ?s .
           ?s a ?type .
         }

--- a/repository/collectors/meeting-collection.js
+++ b/repository/collectors/meeting-collection.js
@@ -32,6 +32,7 @@ async function collectMeetings(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?agenda a besluitvorming:Agenda .
           ?agenda ${path} ?s .
           ?s a ?type .
         }
@@ -64,6 +65,7 @@ async function collectPublicationActivities(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?meeting a besluit:Vergaderactiviteit .
           ?meeting ${path} ?s .
           ?s a ?type .
         }

--- a/repository/collectors/publication-collection.js
+++ b/repository/collectors/publication-collection.js
@@ -51,6 +51,7 @@ async function collectPublicationFlows(distributor) {
         }
         GRAPH <${distributor.sourceGraph}> {
           ${decisionsReleaseFilter(distributor.releaseOptions.validateDecisionsRelease)}
+          ?piece a dossier:Stuk .
           ?piece ${path} ?s .
           ?s a ?type .
         }
@@ -84,6 +85,7 @@ async function collectTranslationSubcasesAndActivities(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?pubFlow a pub:Publicatieaangelegenheid .
           ?pubFlow ${path} ?s .
           ?s a ?type .
         }
@@ -118,6 +120,7 @@ async function collectPublicationSubcasesAndActivities(distributor) {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${distributor.sourceGraph}> {
+          ?pubFlow a pub:Publicatieaangelegenheid .
           ?pubFlow ${path} ?s .
           ?s a ?type .
         }

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -131,59 +131,43 @@ class Distributor {
 
           // Outgoing triples
           await updateTriplestore(`
-          INSERT {
-            GRAPH <${this.tempGraph}> {
-              ?resource ?p ?o .
-            }
-          } WHERE {
-            {
-              SELECT ?resource ?p ?o WHERE {
-                {
-                  SELECT ?resource {
-                    SELECT DISTINCT ?resource {
-                      GRAPH <${this.tempGraph}> {
-                        ?resource a <${type}> .
-                      }
-                    } ORDER BY ?resource
-                  } LIMIT ${limit} OFFSET ${offset}
-                }
-                {
-                  GRAPH <${this.sourceGraph}> {
-                    ?resource ?p ?o .
-                  }
-                }
+            INSERT {
+              GRAPH <${this.tempGraph}> {
+                ?resource ?p ?o .
               }
-            }
-          }
-        `);
+            } WHERE {
+              {
+                SELECT DISTINCT ?resource {
+                  GRAPH <${this.tempGraph}> {
+                    ?resource a <${type}> .
+                  }
+                } ORDER BY ?resource LIMIT ${limit} OFFSET ${offset}
+              }
+              GRAPH <${this.sourceGraph}> {
+                ?resource a <${type}> . # for Virtuoso performance
+                ?resource ?p ?o .
+              }
+            }`);
 
           // Incoming triples
           await updateTriplestore(`
-          INSERT {
-            GRAPH <${this.tempGraph}> {
-              ?s ?p ?resource .
-            }
-          } WHERE {
-            {
-              SELECT ?s ?p ?resource WHERE {
-                {
-                  SELECT ?resource {
-                    SELECT DISTINCT ?resource {
-                      GRAPH <${this.tempGraph}> {
-                        ?resource a <${type}> .
-                      }
-                    } ORDER BY ?resource
-                  } LIMIT ${limit} OFFSET ${offset}
-                }
-                {
-                  GRAPH <${this.sourceGraph}> {
-                    ?s ?p ?resource .
-                  }
-                }
+            INSERT {
+              GRAPH <${this.tempGraph}> {
+                ?s ?p ?resource .
               }
-            }
-          }
-        `);
+            } WHERE {
+              {
+                SELECT DISTINCT ?resource {
+                  GRAPH <${this.tempGraph}> {
+                    ?resource a <${type}> .
+                  }
+                } ORDER BY ?resource LIMIT ${limit} OFFSET ${offset}
+              }
+              GRAPH <${this.sourceGraph}> {
+                ?resource a <${type}> . # for Virtuoso performance
+                ?s ?p ?resource .
+              }
+            }`)
         });
 
         currentBatch++;

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -150,6 +150,7 @@ export default class CabinetDistributor extends Distributor {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${this.sourceGraph}> {
+          ?piece a dossier:Stuk .
           ?piece prov:value ?file ;
                  besluitvorming:vertrouwelijkheidsniveau ?accessLevel .
           FILTER( ?accessLevel IN (<${ACCESS_LEVEL_CABINET}>, <${ACCESS_LEVEL_GOVERNMENT}>, <${ACCESS_LEVEL_PUBLIC}>) )

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -154,6 +154,7 @@ export default class GovernmentDistributor extends Distributor {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${this.sourceGraph}> {
+          ?piece a dossier:Stuk .
           ?piece prov:value ?file ;
                  besluitvorming:vertrouwelijkheidsniveau ?accessLevel .
           FILTER( ?accessLevel IN (<${ACCESS_LEVEL_GOVERNMENT}>, <${ACCESS_LEVEL_PUBLIC}>) )

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -144,6 +144,7 @@ export default class MinisterDistributor extends Distributor {
               ext:tracesLineageTo ?agenda .
         }
         GRAPH <${this.sourceGraph}> {
+          ?piece a dossier:Stuk .
           ?piece prov:value ?file ;
                  besluitvorming:vertrouwelijkheidsniveau ?accessLevel .
           FILTER ( ?accessLevel != <${ACCESS_LEVEL_SECRETARY}> )

--- a/repository/query-helpers.js
+++ b/repository/query-helpers.js
@@ -1,6 +1,6 @@
 import { sparqlEscape, sparqlEscapeUri } from 'mu';
 import { querySudo as query, updateSudo as update } from './auth-sudo';
-import { MU_AUTH_PAGE_SIZE, VIRTUOSO_RESOURCE_PAGE_SIZE } from '../config';
+import { MU_AUTH_PAGE_SIZE } from '../config';
 
 /**
  * Convert results of select query to an array of objects.


### PR DESCRIPTION
- remove some wrapping curlies and selects
- add type in WHERE to lighten query for triplestore

The last bullet point is likely a query optimization which triggers now.
Although there's a bit more constrained in this solution, the total result set
is fairly small in queries where it fails.