### PR TITLE
Add script to reset distribution graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ export default [
 By default, Yggdrasil assumes the initial load has been done. The initial load has to be enabled specifically, and disabled afterwards. During initial load, deltas will not be handled, but queued for future processing.
 
 Before starting the initial load, the target graphs need to be cleaned manually.
-For each user group, execute
 ```sparql
-DROP SILENT GRAPH <user group graph>
+mu script yggdrasil reset
 ```
 
 When the the `RELOAD_ON_INIT` flag is enabled on start-up of Yggdrasil, the initial load will be triggered.

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.1",
+  "scripts": [
+    {
+      "documentation": {
+        "command": "reset",
+        "description": "Reset graphs to which data is distributed",
+        "arguments": []
+      },
+      "environment": {
+        "image": "alpine/curl",
+        "interactive": false,
+        "script": "reset/run.sh",
+        "join_networks": true
+      }
+    }
+  ]
+}

--- a/scripts/reset/run.sh
+++ b/scripts/reset/run.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+echo ""
+echo "Going to drop minister graph in triplestore"
+curl -X DELETE --url "http://triplestore:8890/sparql-graph-crud?graph=http://mu.semte.ch/graphs/organizations/minister"
+
+echo ""
+echo "Going to drop intern-regering graph in triplestore"
+curl -X DELETE --url "http://triplestore:8890/sparql-graph-crud?graph=http://mu.semte.ch/graphs/organizations/intern-regering"
+
+echo ""
+echo "Going to drop intern-overheid graph in triplestore"
+curl -X DELETE --url "http://triplestore:8890/sparql-graph-crud?graph=http://mu.semte.ch/graphs/organizations/intern-overheid"
+
+echo ""
+echo "DONE"


### PR DESCRIPTION
Add a mu script to drop the distribution graphs before executing an new initial distribution.