### PR TITLE
Refactor ignored types

### DIFF
--- a/model.js
+++ b/model.js
@@ -14,6 +14,7 @@ const prefixes = {
   'nfo': 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
 };
 
+// Make sure at least 1 path exists in pathsFromAgenda for each key here
 const typeUris = [
   { key: 'agenda', uri: 'besluitvorming:Agenda' },
   { key: 'meeting', uri: 'besluit:Vergaderactiviteit' },
@@ -154,6 +155,9 @@ const pathsFromAgenda = {
   ],
   publicationActivity: [
     { source: 'publicationSubcase', predicate: '^pub:publicatieVindtPlaatsTijdens' }
+  ],
+  file: [
+    { source: 'piece', predicate: 'prov:value' }
   ],
 };
 

--- a/model.js
+++ b/model.js
@@ -8,6 +8,10 @@ const prefixes = {
   'sign': 'http://mu.semte.ch/vocabularies/ext/handtekenen/',
   'pub': 'http://mu.semte.ch/vocabularies/ext/publicatie/',
   'adms': 'http://www.w3.org/ns/adms#',
+  'generiek': 'https://data.vlaanderen.be/ns/generiek#',
+  'person': 'http://www.w3.org/ns/person#',
+  'schema': 'http://schema.org/',
+  'nfo': 'http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#',
 };
 
 const typeUris = [
@@ -15,6 +19,7 @@ const typeUris = [
   { key: 'meeting', uri: 'besluit:Vergaderactiviteit' },
   { key: 'internalDecisionPublicationActivity', uri: 'ext:InternalDecisionPublicationActivity' },
   { key: 'internalDocumentPublicationActivity', uri: 'ext:InternalDocumentPublicationActivity' },
+  { key: 'themisPublicationActivity', uri: 'ext:ThemisPublicationActivity' },
   { key: 'agendaitem', uri: 'besluit:Agendapunt' },
   { key: 'agendaActivity', uri: 'besluitvorming:Agendering' },
   { key: 'agendaStatusActivity', uri: 'ext:AgendaStatusActivity' },
@@ -24,6 +29,9 @@ const typeUris = [
   { key: 'decisionmakingFlow', uri: 'besluitvorming:Besluitvormingsaangelegenheid' },
   { key: 'publicationFlow', uri: 'pub:Publicatieaangelegenheid' },
   { key: 'identification', uri: 'adms:Identifier' },
+  { key: 'structuredIdentifier', uri: 'generiek:GestructureerdeIdentificator' },
+  { key: 'contactPerson', uri: 'schema:ContactPoint' },
+  { key: 'person', uri: 'person:Person' },
   { key: 'translationSubcase', uri: 'pub:VertalingProcedurestap' },
   { key: 'publicationSubcase', uri: 'pub:PublicatieProcedurestap' },
   { key: 'requestActivity', uri: 'pub:AanvraagActiviteit' },
@@ -36,7 +44,8 @@ const typeUris = [
   { key: 'piece', uri: 'dossier:Stuk' },
   { key: 'signedPiece', uri: 'dossier:Stuk' },
   { key: 'signedPieceCopy', uri: 'dossier:Stuk' },
-  { key: 'documentContainer', uri: 'dossier:Serie' }
+  { key: 'documentContainer', uri: 'dossier:Serie' },
+  { key: 'file', uri: 'nfo:FileDataObject' }
 ];
 
 // TODO refactor collectors to make use of this model configuration to construct query paths
@@ -50,6 +59,9 @@ const pathsFromAgenda = {
   ],
   internalDocumentPublicationActivity: [
     { source: 'meeting', predicate: '^ext:internalDocumentPublicationActivityUsed' }
+  ],
+  themisPublicationActivity: [
+    { source: 'meeting', predicate: '^prov:used' }
   ],
   agendaitem: [
     { predicate: 'dct:hasPart' }
@@ -109,6 +121,15 @@ const pathsFromAgenda = {
   ],
   identification: [
     { source: 'publicationFlow', predicate: 'adms:identifier' }
+  ],
+  structuredIdentifier: [
+    { source: 'identification', predicate: 'generiek:gestructureerdeIdentificator' }
+  ],
+  contactPerson: [
+    { source: 'publicationFlow', predicate: 'prov:qualifiedDelegation' }
+  ],
+  person: [
+    { source: 'contactPerson', predicate: '^schema:contactPoint' }
   ],
   translationSubcase: [
     { source: 'publicationFlow', predicate: 'pub:doorlooptVertaling' }

--- a/model.js
+++ b/model.js
@@ -48,6 +48,11 @@ const typeUris = [
   { key: 'file', uri: 'nfo:FileDataObject' }
 ];
 
+const typesToIgnore = [
+  'ext:TempGraph', // Internal Yggdrasil type
+  'prov:Activity', // Subclasses are configured for distribution
+];
+
 // TODO refactor collectors to make use of this model configuration to construct query paths
 const pathsFromAgenda = {
   meeting: [
@@ -155,5 +160,6 @@ const pathsFromAgenda = {
 export {
   prefixes,
   typeUris,
+  typesToIgnore,
   pathsFromAgenda
 }

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -6,10 +6,11 @@ import { countResources, deleteResource } from './query-helpers';
 import { USE_DIRECT_QUERIES, MU_AUTH_PAGE_SIZE, VIRTUOSO_RESOURCE_PAGE_SIZE, KEEP_TEMP_GRAPH } from '../config';
 
 class Distributor {
-  constructor({ sourceGraph, targetGraph }) {
+  constructor({ sourceGraph, targetGraph, model }) {
     this.sourceGraph = sourceGraph;
     this.targetGraph = targetGraph;
     this.tempGraph = `http://mu.semte.ch/graphs/temp/${uuid()}`;
+    this.model = model;
 
     this.releaseOptions = {
       validateDecisionsRelease: false,

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -103,20 +103,14 @@ class Distributor {
     });
 
     const types = summary.results.bindings.map(b => b['type'].value);
+    const relevantTypes = types.filter((type) => this.model.isRelevantType(type));
+    const missingTypes = types.filter((type) => !this.model.isConfiguredType(type));
+    if (missingTypes.length) {
+      console.log(`The following types are found in the temp graph but not configured in the Yggdrasil model to be distributed or ignored. You may want to add these to the config.`);
+      missingTypes.forEach((type) => console.log(`\t - ${type}`));
+    }
 
-    // We are not interested in redistributing certain types because
-    // they hold the same resource triples attached to another type.
-    // E.g. the triples of a resource gathered from prov:Activity or from
-    // besluitvorming:Agendering are identical. Distributing both is a
-    // waste of work for Yggdrasil.
-    const skippedTypes = ['http://www.w3.org/ns/prov#Activity'];
-
-    for (let type of types) {
-      if (skippedTypes.includes(type)) {
-        console.log(`Skipping detail collection of type <${type}>`);
-        continue;
-      }
-
+    for (let type of relevantTypes) {
       const count = await countResources({ graph: this.tempGraph, type: type });
 
       const limit = VIRTUOSO_RESOURCE_PAGE_SIZE;

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -41,10 +41,11 @@ import {
  * Distributor for cabinet (intern-regering) profile
  */
 export default class CabinetDistributor extends Distributor {
-  constructor() {
+  constructor(model) {
     super({
       sourceGraph: ADMIN_GRAPH,
-      targetGraph: CABINET_GRAPH
+      targetGraph: CABINET_GRAPH,
+      model,
     });
 
     this.releaseOptions = {

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -40,10 +40,11 @@ import {
  * Distributor for government (intern-overheid) profile
  */
 export default class GovernmentDistributor extends Distributor {
-  constructor() {
+  constructor(model) {
     super({
       sourceGraph: ADMIN_GRAPH,
-      targetGraph: GOVERNMENT_GRAPH
+      targetGraph: GOVERNMENT_GRAPH,
+      model
     });
 
     this.releaseOptions = {

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -34,10 +34,11 @@ import {
  * Distributor for minister profile
  */
 export default class MinisterDistributor extends Distributor {
-  constructor() {
+  constructor(model) {
     super({
       sourceGraph: ADMIN_GRAPH,
-      targetGraph: MINISTER_GRAPH
+      targetGraph: MINISTER_GRAPH,
+      model,
     });
 
     this.releaseOptions = {

--- a/repository/model-cache.js
+++ b/repository/model-cache.js
@@ -71,7 +71,7 @@ export default class ModelCache {
     }
   }
 
-  getSparqlPrefixes() {
+  get sparqlPrefixes() {
     return Object.keys(prefixes).map((prefix) => {
       return `PREFIX ${prefix}: <${prefixes[prefix]}>`;
     }).join('\n');

--- a/repository/model-cache.js
+++ b/repository/model-cache.js
@@ -1,32 +1,22 @@
-import { prefixes, typeUris, pathsFromAgenda } from '../model';
+import { prefixes, typeUris, typesToIgnore, pathsFromAgenda } from '../model';
 import { LOG_INITIALIZATION } from '../config';
 
 export default class ModelCache {
   constructor() {
     this.pathCache = {};
     this.typeCache = [];
+    this.typesToIgnore = [];
     this.build();
   }
 
   build() {
+    this.typesToIgnore = typesToIgnore.map((uri) => this.resolvePrefix(uri));
+
     // Building a type cache containing non-prefixed entries
     // like { key: 'agenda', uri: 'https://data.vlaanderen.be/ns/besluitvorming#Agenda' }
-    this.typeCache = typeUris.map(entry => {
-      const prefixedType = entry.uri;
-      const parts = prefixedType.split(':');
-      if (parts.length > 1) {
-        const prefix = parts[0];
-        const prefixUri = prefixes[prefix];
-
-        if (prefix) {
-          const resolvedType = prefixedType.replace(`${prefix}:`, prefixUri);
-          return { key: entry.key, uri: resolvedType };
-        } else {
-          throw new Error(`No prefix definition found for '${prefix}'. Please fix the model configuration.`);
-        }
-      } else {
-        return entry;
-      }
+    this.typeCache = typeUris.map(({ key, uri }) => {
+      const resolvedUri = this.resolvePrefix(uri);
+      return { key, uri: resolvedUri };
     });
     if (LOG_INITIALIZATION)
       console.log(`Type cache: ${JSON.stringify(this.typeCache)}`);
@@ -38,6 +28,33 @@ export default class ModelCache {
         const propertyPathsForKey = this.pathCache[key].map(path => path.join(' / '));
         console.log(`Constructed paths from '${key}' to 'agenda': ${JSON.stringify(propertyPathsForKey, null, 4)}`);
       }
+    }
+  }
+
+  isRelevantType(type) {
+    return !this.typesToIgnore.includes(type)
+      && this.typeCache.some(({ uri }) => type == uri);
+  }
+
+  isConfiguredType(type) {
+    return this.typesToIgnore.includes(type)
+      || this.typeCache.some(({ uri }) => type == uri);
+  }
+
+  resolvePrefix(prefixedUri) {
+    const parts = prefixedUri.split(':');
+    if (parts.length > 1) {
+      const prefix = parts[0];
+      const prefixUri = prefixes[prefix];
+
+      if (prefix) {
+        const resolvedUri = prefixedUri.replace(`${prefix}:`, prefixUri);
+        return resolvedUri;
+      } else {
+        throw new Error(`No prefix definition found for '${prefix}'. Please fix the model configuration.`);
+      }
+    } else {
+      return prefixedUri; // URI doesn't contain a prefix
     }
   }
 


### PR DESCRIPTION
No functional change. Code cleanup such that irrelevant types can be configured in `model.js` instead of being hardcoded inline in code.