### PR TITLE
Optimize file collection

### DIFF
--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -103,12 +103,12 @@ export default class CabinetDistributor extends Distributor {
         await this.collectVisibleFiles();
       }, this.constructor.name);
 
-      await runStage('Collect physical files', async () => {
-        await collectPhysicalFiles(this);
-      }, this.constructor.name);
-
       await runStage('Collect derived files', async() => {
         await collectDerivedFiles(this);
+      }, this.constructor.name);
+
+      await runStage('Collect physical files', async () => {
+        await collectPhysicalFiles(this);
       }, this.constructor.name);
 
       await runStage('Collect publication-flows', async() => {

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -102,12 +102,12 @@ export default class GovernmentDistributor extends Distributor {
         await this.collectVisibleFiles();
       }, this.constructor.name);
 
-      await runStage('Collect physical files', async () => {
-        await collectPhysicalFiles(this);
-      }, this.constructor.name);
-
       await runStage('Collect derived files', async() => {
         await collectDerivedFiles(this);
+      }, this.constructor.name);
+
+      await runStage('Collect physical files', async () => {
+        await collectPhysicalFiles(this);
       }, this.constructor.name);
 
       await runStage('Collect publication-flows', async() => {

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -97,12 +97,12 @@ export default class MinisterDistributor extends Distributor {
         await this.collectVisibleFiles();
       }, this.constructor.name);
 
-      await runStage('Collect physical files', async () => {
-        await collectPhysicalFiles(this);
-      }, this.constructor.name);
-
       await runStage('Collect derived files', async() => {
         await collectDerivedFiles(this);
+      }, this.constructor.name);
+
+      await runStage('Collect physical files', async () => {
+        await collectPhysicalFiles(this);
       }, this.constructor.name);
 
       await runStage('Collect publication-flows', async() => {


### PR DESCRIPTION
Simplify query to collect derived files by collecting all physical files after collecting virtual and derived files.

Order previously:
1. Collect virtual files
2. Collect physical files of virtual files from step 1
3. Collect derived files together with their physical files (more complex query)

New order:
1. Collect virtual files
2. Collect derived files
3. Collect physical files of virtual files from step 1 and derived files from step 2