### PR TITLE
Optimize publication flow collection

### DIFF
--- a/repository/collectors/publication-collection.js
+++ b/repository/collectors/publication-collection.js
@@ -21,11 +21,6 @@ import { decisionsReleaseFilter } from './release-validations';
 async function collectPublicationFlows(distributor) {
   const properties = [
     [ '^pub:referentieDocument' ], // publication-flow
-    [ '^pub:referentieDocument', 'adms:identifier' ], // identification
-    [ '^pub:referentieDocument', 'adms:identifier', 'generiek:gestructureerdeIdentificator' ], // structured-identifier
-    [ '^pub:referentieDocument', 'pub:identifier' ], // numac-numbers
-    [ '^pub:referentieDocument', 'prov:qualifiedDelegation' ], // contact-persons
-    [ '^pub:referentieDocument', 'prov:qualifiedDelegation', '^schema:contactPoint' ], // contact-persons users
   ];
   const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
 
@@ -33,11 +28,8 @@ async function collectPublicationFlows(distributor) {
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
       PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
-      PREFIX adms: <http://www.w3.org/ns/adms#>
-      PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
       PREFIX prov: <http://www.w3.org/ns/prov#>
-      PREFIX generiek:  <https://data.vlaanderen.be/ns/generiek#>
-      PREFIX schema: <http://schema.org/>
+      PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
 
       INSERT {
         GRAPH <${distributor.tempGraph}> {
@@ -59,55 +51,28 @@ async function collectPublicationFlows(distributor) {
   await updateTriplestore(relatedQuery);
 }
 
-async function collectTranslationSubcasesAndActivities(distributor) {
+async function collectPublicationFlowSubcasesAndActivities(distributor) {
   const properties = [
     [ 'pub:doorlooptVertaling' ], // translation-subcase
     [ 'pub:doorlooptVertaling', '^pub:vertalingVindtPlaatsTijdens' ], // translation-activities
-  ];
-  const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
-
-  const relatedQuery = `
-      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
-      PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
-      PREFIX adms: <http://www.w3.org/ns/adms#>
-      PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
-      PREFIX prov: <http://www.w3.org/ns/prov#>
-
-      INSERT {
-        GRAPH <${distributor.tempGraph}> {
-          ?s a ?type ;
-             ext:tracesLineageTo ?agenda .
-        }
-      } WHERE {
-        GRAPH <${distributor.tempGraph}> {
-          ?pubFlow a pub:Publicatieaangelegenheid ;
-              ext:tracesLineageTo ?agenda .
-        }
-        GRAPH <${distributor.sourceGraph}> {
-          ?pubFlow a pub:Publicatieaangelegenheid .
-          ?pubFlow ${path} ?s .
-          ?s a ?type .
-        }
-      }`;
-  await updateTriplestore(relatedQuery);
-}
-
-async function collectPublicationSubcasesAndActivities(distributor) {
-  const properties = [
     [ 'pub:doorlooptPublicatie' ], // publication-subcase
     [ 'pub:doorlooptPublicatie', '^pub:drukproefVindtPlaatsTijdens' ], // proofing-activities
-    [ 'pub:doorlooptPublicatie', '^pub:publicatieVindtPlaatsTijdens' ] // publication-activities
+    [ 'pub:doorlooptPublicatie', '^pub:publicatieVindtPlaatsTijdens' ], // publication-activities
+    [ 'adms:identifier' ], // identification
+    [ 'adms:identifier', 'generiek:gestructureerdeIdentificator' ], // structured-identifier
+    [ 'pub:identifier' ], // numac-numbers
+    [ 'prov:qualifiedDelegation' ], // contact-persons
+    [ 'prov:qualifiedDelegation', '^schema:contactPoint' ], // contact-persons users
   ];
   const path = properties.map(prop => prop.join(' / ')).map(path => `( ${path} )`).join(' | ');
 
   const relatedQuery = `
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX pub: <http://mu.semte.ch/vocabularies/ext/publicatie/>
-      PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
       PREFIX adms: <http://www.w3.org/ns/adms#>
-      PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
       PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX generiek:  <https://data.vlaanderen.be/ns/generiek#>
+      PREFIX schema: <http://schema.org/>
 
       INSERT {
         GRAPH <${distributor.tempGraph}> {
@@ -130,6 +95,5 @@ async function collectPublicationSubcasesAndActivities(distributor) {
 
 export {
   collectPublicationFlows,
-  collectTranslationSubcasesAndActivities,
-  collectPublicationSubcasesAndActivities
+  collectPublicationFlowSubcasesAndActivities
 }

--- a/repository/distributors/cabinet-distributor.js
+++ b/repository/distributors/cabinet-distributor.js
@@ -33,8 +33,7 @@ import {
 } from '../collectors/document-collection';
 import {
   collectPublicationFlows,
-  collectTranslationSubcasesAndActivities,
-  collectPublicationSubcasesAndActivities
+  collectPublicationFlowSubcasesAndActivities,
 } from '../collectors/publication-collection';
 
 /**
@@ -115,12 +114,8 @@ export default class CabinetDistributor extends Distributor {
         await collectPublicationFlows(this);
       }, this.constructor.name);
 
-      await runStage('Collect translation-subcases', async() => {
-        await collectTranslationSubcasesAndActivities(this);
-      }, this.constructor.name);
-
-      await runStage('Collect publication-subcases', async() => {
-        await collectPublicationSubcasesAndActivities(this);
+      await runStage('Collect publication-flow subcases and activities', async() => {
+        await collectPublicationFlowSubcasesAndActivities(this);
       }, this.constructor.name);
     }
 

--- a/repository/distributors/government-distributor.js
+++ b/repository/distributors/government-distributor.js
@@ -32,8 +32,7 @@ import {
 } from '../collectors/document-collection';
 import {
   collectPublicationFlows,
-  collectTranslationSubcasesAndActivities,
-  collectPublicationSubcasesAndActivities
+  collectPublicationFlowSubcasesAndActivities,
 } from '../collectors/publication-collection';
 
 /**
@@ -114,12 +113,8 @@ export default class GovernmentDistributor extends Distributor {
         await collectPublicationFlows(this);
       }, this.constructor.name);
 
-      await runStage('Collect translation-subcases', async() => {
-        await collectTranslationSubcasesAndActivities(this);
-      }, this.constructor.name);
-
-      await runStage('Collect publication-subcases', async() => {
-        await collectPublicationSubcasesAndActivities(this);
+      await runStage('Collect publication-flow subcases and activities', async() => {
+        await collectPublicationFlowSubcasesAndActivities(this);
       }, this.constructor.name);
     }
 

--- a/repository/distributors/minister-distributor.js
+++ b/repository/distributors/minister-distributor.js
@@ -26,8 +26,7 @@ import {
 } from '../collectors/document-collection';
 import {
   collectPublicationFlows,
-  collectTranslationSubcasesAndActivities,
-  collectPublicationSubcasesAndActivities
+  collectPublicationFlowSubcasesAndActivities,
 } from '../collectors/publication-collection';
 
 /**
@@ -109,12 +108,8 @@ export default class MinisterDistributor extends Distributor {
         await collectPublicationFlows(this);
       }, this.constructor.name);
 
-      await runStage('Collect translation-subcases', async() => {
-        await collectTranslationSubcasesAndActivities(this);
-      }, this.constructor.name);
-
-      await runStage('Collect publication-subcases', async() => {
-        await collectPublicationSubcasesAndActivities(this);
+      await runStage('Collect publication-flow subcases and activities', async() => {
+        await collectPublicationFlowSubcasesAndActivities(this);
       }, this.constructor.name);
     }
 


### PR DESCRIPTION
Simplify the query to collect all publication flows, by first collecting only publication flows and only afterwards collecting all related subcases/activities.