### PR TITLE
KAS-5211 add job model to distributor logic to follow the process per graph

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -14,6 +14,18 @@ const ACCESS_LEVEL_PUBLIC = 'http://themis.vlaanderen.be/id/concept/toegangsnive
 const DECISION_STATUS_APPROVED = 'http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/56312c4b-9d2a-4735-b0b1-2ff14bb524fd';
 const DECISION_STATUS_ACKNOWLEDGED = 'http://themis.vlaanderen.be/id/concept/beslissing-resultaatcodes/9f342a88-9485-4a83-87d9-245ed4b504bf';
 
+const JOB = {
+  JSONAPI_JOB_TYPE: "distributor-jobs",
+  RDF_TYPE: "http://mu.semte.ch/vocabularies/ext/DistributorJob",
+  RESOURCE_BASE: "http://mu.semte.ch/services/yggdrasil",
+  STATUSES: {
+    SCHEDULED: "http://redpencil.data.gift/id/concept/JobStatus/scheduled",
+    BUSY: "http://redpencil.data.gift/id/concept/JobStatus/busy",
+    SUCCESS: "http://redpencil.data.gift/id/concept/JobStatus/success",
+    FAILED: "http://redpencil.data.gift/id/concept/JobStatus/failed",
+  },
+};
+
 export {
   ADMIN_GRAPH,
   MINISTER_GRAPH,
@@ -27,4 +39,5 @@ export {
   ACCESS_LEVEL_PUBLIC,
   DECISION_STATUS_APPROVED,
   DECISION_STATUS_ACKNOWLEDGED,
+  JOB
 }

--- a/repository/distributor-job.js
+++ b/repository/distributor-job.js
@@ -1,0 +1,131 @@
+import {
+  uuid as generateUuid,
+  sparqlEscapeUri,
+  sparqlEscapeString,
+  sparqlEscapeDateTime,
+} from "mu";
+import { updateSudo } from "./auth-sudo";
+import { JOB } from "../constants";
+
+async function createDistributorJobs(deltaDistributors, agendaUris) {
+
+  for (let distributor of deltaDistributors) {
+    console.log('creating distributor jobs');
+    const job = await createJob(distributor.targetGraph, agendaUris);
+    distributor.jobUri = job.uri;
+  }
+}
+
+async function createJob(distributorGraph, agendaUris) {
+  const uuid = generateUuid();
+  const job = {
+    uri: JOB.RESOURCE_BASE + `/${JOB.JSONAPI_JOB_TYPE}/${uuid}`,
+    id: uuid,
+    status: JOB.STATUSES.SCHEDULED,
+    created: new Date(),
+  };
+  const queryString = `
+  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+  PREFIX dct: <http://purl.org/dc/terms/>
+  PREFIX cogs: <http://vocab.deri.ie/cogs#>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
+  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+  INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+      ${sparqlEscapeUri(job.uri)} a ${sparqlEscapeUri(JOB.RDF_TYPE)} ; # also a cogs:Job in spirit , not sure we want it
+        mu:uuid ${sparqlEscapeString(job.id)} ;
+        adms:status ${sparqlEscapeUri(job.status)} ;
+        ${agendaUris.length ? `prov:used ${agendaUris.map(sparqlEscapeUri).join(", ")} ;` : ""}
+        ext:targetGraph ${sparqlEscapeString(distributorGraph)} ;
+        dct:created ${sparqlEscapeDateTime(job.created)} .
+    }
+  }`;
+  await updateSudo(queryString);
+  return job;
+}
+
+async function updateJobStatus(uri, status, errorMessage = '') {
+  const time = new Date();
+  let timePred;
+  if (status === JOB.STATUSES.SUCCESS || status === JOB.STATUSES.FAILED) {
+    // final statusses
+    timePred = "http://www.w3.org/ns/prov#endedAtTime";
+  } else {
+    timePred = "http://www.w3.org/ns/prov#startedAtTime";
+  }
+  const escapedUri = sparqlEscapeUri(uri);
+  const queryString = `
+  PREFIX cogs: <http://vocab.deri.ie/cogs#>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX schema: <http://schema.org/>
+
+  DELETE {
+      GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+          ${escapedUri} adms:status ?status ;
+              ${sparqlEscapeUri(timePred)} ?time .
+      }
+  }
+  INSERT {
+      GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+          ${escapedUri} adms:status ${sparqlEscapeUri(status)} .
+          ${
+            status !== JOB.STATUSES.SCHEDULED
+              ? `${escapedUri} ${sparqlEscapeUri(timePred)} ${sparqlEscapeDateTime(time)} .`
+              : ""
+          }
+          ${
+            errorMessage
+              ? `${escapedUri} schema:error ${sparqlEscapeString(errorMessage)} .`
+              : ""
+          }
+      }
+  }
+  WHERE {
+      GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+          ${escapedUri} a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
+          OPTIONAL { ${escapedUri} adms:status ?status }
+          OPTIONAL { ${escapedUri} ${sparqlEscapeUri(timePred)} ?time }
+      }
+  }`;
+  await updateSudo(queryString);
+}
+
+async function failUnfinishedDistributorJobs(errorMessage) {
+  const queryString = `
+  PREFIX cogs: <http://vocab.deri.ie/cogs#>
+  PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX schema: <http://schema.org/>
+  PREFIX prov: <http://www.w3.org/ns/prov#>
+
+  DELETE {
+      GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+          ?distributionJob adms:status ?status ;
+              prov:endedAtTime ?time .
+      }
+  }
+  INSERT {
+      GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+          ?distributionJob adms:status ${sparqlEscapeUri(JOB.STATUSES.FAILED)} .
+          ?distributionJob prov:endedAtTime ${sparqlEscapeDateTime(new Date())} .
+          ?distributionJob schema:error ${sparqlEscapeString(errorMessage)} .
+      }
+  }
+  WHERE {
+      GRAPH <http://mu.semte.ch/graphs/organizations/kanselarij> {
+          ?distributionJob a ${sparqlEscapeUri(JOB.RDF_TYPE)} .
+          ?distributionJob adms:status ?status .
+          OPTIONAL { ?distributionJob prov:endedAtTime ?time }
+          FILTER( ?status IN (<${JOB.STATUSES.SCHEDULED}>, <${JOB.STATUSES.BUSY}>) )
+      }
+  }`;
+  await updateSudo(queryString);
+}
+
+export {
+  createDistributorJobs,
+  createJob,
+  updateJobStatus,
+  failUnfinishedDistributorJobs
+};

--- a/repository/distributor.js
+++ b/repository/distributor.js
@@ -6,6 +6,8 @@ import { countTriples, deleteResource } from './query-helpers';
 import { cleanupPublicationFlowDetails } from './collectors/publication-collection';
 import { cleanupEmptyAgendaitemTreatments } from './collectors/decision-collection';
 import { USE_DIRECT_QUERIES, MU_AUTH_PAGE_SIZE, VIRTUOSO_RESOURCE_PAGE_SIZE, KEEP_TEMP_GRAPH } from '../config';
+import { JOB } from '../constants';
+import { updateJobStatus } from './distributor-job';
 
 class Distributor {
   constructor({ sourceGraph, targetGraph, model }) {
@@ -15,6 +17,7 @@ class Distributor {
     this.tempGraphSubjectsIn = `${this.tempGraph}/subjects-in`;
     this.tempGraphSubjectsOut = `${this.tempGraph}/subjects-out`;
     this.model = model;
+    this.jobUri = '';
 
     this.releaseOptions = {
       validateDecisionsRelease: false,
@@ -25,6 +28,7 @@ class Distributor {
   async perform(options = { agendaUris: [], isInitialDistribution: false }) {
     if (this.collect) {
       console.log(`${this.constructor.name} started at ${new Date().toISOString()}`);
+      await updateJobStatus(this.jobUri, JOB.STATUSES.BUSY);
 
       await runStage(`Register temp graph <${this.tempGraph}>`, async () => {
         await this.registerTempGraph();
@@ -70,6 +74,7 @@ class Distributor {
         });
       }
 
+      await updateJobStatus(this.jobUri, JOB.STATUSES.SUCCESS);
       console.log(`${this.constructor.name} ended at ${new Date().toISOString()}`);
     } else {
       console.warn(`Distributor ${this.constructor.name} doesn't contain a function this.collect(). Nothing to perform.`);

--- a/repository/yggdrasil.js
+++ b/repository/yggdrasil.js
@@ -85,7 +85,7 @@ export default class Yggdrasil {
           const subjects = reduceChangesets(delta);
           const agendas = await fetchRelatedAgendas(subjects, this.model);
           if (agendas.length) {
-            await createDistributorJobs(this.deltaDistributors, { agendaUris: agendas });
+            await createDistributorJobs(this.deltaDistributors, agendas);
             for (let distributor of this.deltaDistributors) {
               await distributor.perform({ agendaUris: agendas });
             }

--- a/repository/yggdrasil.js
+++ b/repository/yggdrasil.js
@@ -7,6 +7,10 @@ import  {
   CabinetDistributor,
   GovernmentDistributor,
 } from './distributors';
+import {
+  createDistributorJobs,
+  failUnfinishedDistributorJobs,
+} from './distributor-job';
 
 export default class Yggdrasil {
 
@@ -81,6 +85,7 @@ export default class Yggdrasil {
           const subjects = reduceChangesets(delta);
           const agendas = await fetchRelatedAgendas(subjects, this.model);
           if (agendas.length) {
+            await createDistributorJobs(this.deltaDistributors, { agendaUris: agendas });
             for (let distributor of this.deltaDistributors) {
               await distributor.perform({ agendaUris: agendas });
             }
@@ -88,14 +93,17 @@ export default class Yggdrasil {
             console.log('Deltas not related to any agenda. Nothing to distribute.');
           }
         } catch(e) {
+          await failUnfinishedDistributorJobs(`Someting went wrong while processing delta's: ${e.message}`);
           console.log("Someting went wrong while processing delta's");
-          console.log(e);
+          console.trace(e);
         } finally {
           this.isProcessing = false;
         }
       }
     }
   }
+
+  // TODO cleanup all jobs on rebuild? they mean nothing after a rebuild
 
   async cleanupTempGraphs() {
     const result = await queryTriplestore(`


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5211

- Added a `ext:DistributionJob` for each graph `ext:targetGraph` per distribution
- Jobs are created before starting the distributions with the detected agendas as `prov:used`
- if any error occures, the entire delta process stops, so we fail all jobs that are not finished yet


example of the data
<img width="1808" height="597" alt="image" src="https://github.com/user-attachments/assets/b2a3818b-329a-4f49-a05d-76da0530d3c3" />
